### PR TITLE
Fix error: 'Could not find `tcp` in `proto`'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-modbus"
 description = "Tokio-based modbus library"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Markus Kohlhase <markus.kohlhase@slowtec.de>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/server.rs
+++ b/src/server.rs
@@ -62,6 +62,7 @@ impl Server {
         }
     }
 
+    #[cfg(feature = "tcp")]
     pub fn serve<S>(&self, service: S)
     where
         S: NewService + Send + Sync + 'static,


### PR DESCRIPTION
This error occurs if you compile tokio-modbus with the feature 'rtu'.