### PR TITLE
Fix decoding of Unit Identifier from TCP ADU header

### DIFF
--- a/src/codec/tcp.rs
+++ b/src/codec/tcp.rs
@@ -80,7 +80,8 @@ impl Decoder for AduDecoder {
         debug_assert!(HEADER_LEN >= 2);
         let transaction_id = BigEndian::read_u16(&header_data[0..2]);
 
-        let unit_id = header_data[4];
+        debug_assert!(HEADER_LEN > 6);
+        let unit_id = header_data[6];
 
         let header = Header {
             transaction_id,


### PR DESCRIPTION
The unit_id was read from byte 5 instead of 7 that contains the hi-byte of the protocol_id, which is always 0x00.

The bug appeared after using the recommended unit_id 0xFF instead of 0x00 and verifying the whole response header of the response instead of only the transaction_id.

v0.2.x is not affected due to the limitations and lucky circumstances ;)