### PR TITLE
Add a Disconnect request to drop the ClientService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.3.2 (2019-04-11)
+
+Potential breaking change: Extending the `Request` enum with the new variant
+`Disconnect` might break existing code. This variant is only used internally
+within the client and will never be sent across the wire and can safely be
+ignored by both clients and servers!
+
+- Client: Added a `Disconnect` request as *poison pill* for stopping
+  the client service and to release the underlying transport.
+
 ## v0.3.1 (2019-04-08)
 
 - RTU client: Use a generic async transport instead of `Serial`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-modbus"
 description = "Tokio-based Modbus library"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["slowtec GmbH", "Markus Kohlhase <markus.kohlhase@slowtec.de>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -81,6 +81,19 @@ pub struct Context {
     client: Box<dyn Client>,
 }
 
+impl Context {
+    pub fn disconnect(&self) -> impl Future<Item = (), Error = Error> {
+        // Disconnecting is expected to fail!
+        self.client.call(Request::Disconnect).then(|res| match res {
+            Ok(_) => unreachable!(),
+            Err(err) => match err.kind() {
+                ErrorKind::NotConnected | ErrorKind::BrokenPipe => Ok(()),
+                _ => Err(err),
+            },
+        })
+    }
+}
+
 impl From<Box<dyn Client>> for Context {
     fn from(client: Box<dyn Client>) -> Self {
         Self { client }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -67,6 +67,7 @@ impl From<Request> for Bytes {
                     data.put_u8(d);
                 }
             }
+            Disconnect => unreachable!(),
         }
         data.freeze()
     }
@@ -398,6 +399,7 @@ fn req_to_fn_code(req: &Request) -> u8 {
         WriteMultipleRegisters(_, _) => 0x10,
         ReadWriteMultipleRegisters(_, _, _, _) => 0x17,
         Custom(code, _) => code,
+        Disconnect => unreachable!(),
     }
 }
 
@@ -430,6 +432,7 @@ fn request_byte_count(req: &Request) -> usize {
         WriteMultipleRegisters(_, ref data) => 6 + data.len() * 2,
         ReadWriteMultipleRegisters(_, _, _, ref data) => 10 + data.len() * 2,
         Custom(_, ref data) => 1 + data.len(),
+        Disconnect => unreachable!(),
     }
 }
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -37,6 +37,16 @@ pub enum Request {
     WriteMultipleRegisters(Address, Vec<Word>),
     ReadWriteMultipleRegisters(Address, Quantity, Address, Vec<Word>),
     Custom(FunctionCode, Vec<u8>),
+    /// A poison pill for stopping the client service and to release
+    /// the underlying transport, e.g. for disconnecting from an
+    /// exclusively used serial port.
+    ///
+    /// This is an ugly workaround, because `tokio-proto` does not
+    /// provide other means to gracefully shut down the `ClientService`.
+    /// Otherwise the bound transport is never freed as long as the
+    /// executor is active, even when dropping the Modbus client
+    /// context.
+    Disconnect,
 }
 
 /// The data of a successfull request.

--- a/src/frame/rtu.rs
+++ b/src/frame/rtu.rs
@@ -11,6 +11,7 @@ pub(crate) struct Header {
 pub(crate) struct RequestAdu {
     pub hdr: Header,
     pub pdu: RequestPdu,
+    pub disconnect: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
A poison pill and ugly workaround. This is the only way to stop the client service and release the underlying transport. A BrokenPipe error will be logged by tokio-proto.

Although public the `Request` enum should not be used in any match expressions by external code. Therefore I recommend that we release this with the next 0.3.x update.