### PR TITLE
Shared context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## v0.3.2 (2019-04-12)
+## v0.3.2 (2019-04-15)
 
 - Client: Added a `Disconnect` request as *poison pill* for stopping
-  the client service and to release the underlying transport.
-- Added utilities to share a Modbus context within a thread for communicating
-  with multiple devices.
-- Added utility functions to disconnect and reconnect stale connections after
-  errors.
+  the client service and to release the underlying transport
+- Added utilities to share a single Modbus context within a thread for
+  communicating with multiple devices
+- Added utility functions to disconnect and reconnect stale connections
+  after errors
 - Minimal Rust version: `1.34.0`
 
 ### Potential breaking change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,21 @@
 # Changelog
 
-## v0.3.2 (2019-04-11)
-
-Potential breaking change: Extending the `Request` enum with the new variant
-`Disconnect` might break existing code. This variant is only used internally
-within the client and will never be sent across the wire and can safely be
-ignored by both clients and servers!
+## v0.3.2 (2019-04-12)
 
 - Client: Added a `Disconnect` request as *poison pill* for stopping
   the client service and to release the underlying transport.
+- Added utilities to share a Modbus context within a thread for communicating
+  with multiple devices.
+- Added utility functions to disconnect and reconnect stale connections after
+  errors.
 - Minimal Rust version: `1.34.0`
+
+### Potential breaking change
+
+Extending the `Request` enum with the new variant `Disconnect` might break
+existing code. This variant is only used internally within the client and
+will never be sent across the wire and can safely be ignored by both clients
+and servers!
 
 ## v0.3.1 (2019-04-08)
 

--- a/examples/rtu-client.rs
+++ b/examples/rtu-client.rs
@@ -1,47 +1,94 @@
-use tokio_modbus::prelude::*;
+use futures::{future, Future};
+
+use std::{cell::RefCell, io::Error, rc::Rc};
+
+use tokio_core::reactor::{Core, Handle};
+
+use tokio_modbus::prelude::{
+    client::util::{reconnect_shared_context, NewContext, SharedContext},
+    *,
+};
 
 const SLAVE_1: Slave = Slave(0x01);
 const SLAVE_2: Slave = Slave(0x02);
 
 #[cfg(feature = "rtu")]
 pub fn main() {
-    use futures::Future;
-    use tokio_core::reactor::Core;
     use tokio_serial::{Serial, SerialPortSettings};
 
     let mut core = Core::new().unwrap();
-    let handle = core.handle();
-    let tty_path = "/dev/ttyUSB0";
 
-    let mut settings = SerialPortSettings::default();
-    settings.baud_rate = 19200;
-    let port = Serial::from_path_with_handle(tty_path, &settings, &handle.new_tokio_handle())
-        .expect(&format!("Unable to open serial device '{}'", tty_path));
+    #[derive(Debug)]
+    struct SerialConfig {
+        path: String,
+        settings: SerialPortSettings,
+        handle: Handle,
+    }
 
-    // On Unix you might disable the `exclusive` flag:
-    // port.set_exclusive(false)
-    //     .expect("Unable to set serial port exlusive");
+    impl NewContext for SerialConfig {
+        fn new_context(&self) -> Box<dyn Future<Item = client::Context, Error = Error>> {
+            let handle = self.handle.clone();
+            Box::new(
+                future::result(Serial::from_path_with_handle(
+                    &self.path,
+                    &self.settings,
+                    &self.handle.new_tokio_handle(),
+                ))
+                .and_then(move |port| rtu::connect(&handle, port)),
+            )
+        }
+    }
 
-    let task = rtu::connect(&handle, port)
-        .and_then(move |mut ctx| {
-            ctx.set_slave(SLAVE_1);
+    let serial_config = SerialConfig {
+        path: "/dev/ttyUSB0".into(),
+        settings: SerialPortSettings {
+            baud_rate: 19200,
+            ..Default::default()
+        },
+        handle: core.handle(),
+    };
+    println!("Configuration: {:?}", serial_config);
+
+    // A shared, reconnectable context is not actually needed in this
+    // simple example. Nevertheless we use it here to demonstrate how
+    // it works.
+    let shared_context = Rc::new(RefCell::new(SharedContext::new(
+        None, // no initial context, i.e. not connected
+        Box::new(serial_config),
+    )));
+
+    // Reconnect for connecting an initial context
+    let task = reconnect_shared_context(&shared_context)
+        .map(move |()| {
+            assert!(shared_context.borrow().is_connected());
+            println!("Connected");
+            shared_context
+        })
+        .and_then(move |shared_context| {
             println!("Reading a sensor value from {:?}", SLAVE_1);
-            ctx.read_holding_registers(0x082B, 2)
-                .and_then(|rsp| Ok((ctx, rsp)))
+            let context = shared_context.borrow().share_context().unwrap();
+            let mut context = context.borrow_mut();
+            context.set_slave(SLAVE_1);
+            context
+                .read_holding_registers(0x082B, 2)
+                .map(move |response| (shared_context, response))
         })
-        .and_then(move |(ctx, rsp)| {
-            println!("Sensor value for device {:?} is: {:?}", SLAVE_1, rsp);
-            Ok(ctx)
+        .map(move |(shared_context, response)| {
+            println!("Sensor value for device {:?} is: {:?}", SLAVE_1, response);
+            shared_context
         })
-        .and_then(|mut ctx| {
-            ctx.set_slave(SLAVE_2);
+        .and_then(move |shared_context| {
             println!("Reading a sensor value from {:?}", SLAVE_2);
-            ctx.read_holding_registers(0x082B, 2)
-                .and_then(|rsp| Ok((ctx, rsp)))
+            let context = shared_context.borrow().share_context().unwrap();
+            let mut context = context.borrow_mut();
+            context.set_slave(SLAVE_2);
+            context
+                .read_holding_registers(0x082B, 2)
+                .map(move |response| (shared_context, response))
         })
-        .and_then(move |(_, rsp)| {
-            println!("Sensor value for device {:?} is: {:?}", SLAVE_2, rsp);
-            Ok(())
+        .map(move |(_, response)| {
+            println!("Sensor value for device {:?} is: {:?}", SLAVE_2, response);
+            // Done
         });
 
     core.run(task).unwrap();

--- a/examples/rtu-client.rs
+++ b/examples/rtu-client.rs
@@ -71,11 +71,10 @@ pub fn main() {
             context.set_slave(SLAVE_1);
             context
                 .read_holding_registers(0x082B, 2)
-                .map(move |response| (shared_context, response))
-        })
-        .map(move |(shared_context, response)| {
-            println!("Sensor value for device {:?} is: {:?}", SLAVE_1, response);
-            shared_context
+                .map(move |response| {
+                    println!("Sensor value for device {:?} is: {:?}", SLAVE_1, response);
+                    shared_context // Continue
+                })
         })
         .and_then(move |shared_context| {
             println!("Reading a sensor value from {:?}", SLAVE_2);
@@ -84,11 +83,10 @@ pub fn main() {
             context.set_slave(SLAVE_2);
             context
                 .read_holding_registers(0x082B, 2)
-                .map(move |response| (shared_context, response))
-        })
-        .map(move |(_, response)| {
-            println!("Sensor value for device {:?} is: {:?}", SLAVE_2, response);
-            // Done
+                .map(move |response| {
+                    println!("Sensor value for device {:?} is: {:?}", SLAVE_2, response);
+                    // Done
+                })
         });
 
     core.run(task).unwrap();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,6 +7,8 @@ pub mod sync;
 #[cfg(feature = "tcp")]
 pub mod tcp;
 
+pub mod util;
+
 use crate::frame::*;
 use crate::slave::*;
 

--- a/src/client/rtu.rs
+++ b/src/client/rtu.rs
@@ -1,3 +1,5 @@
+//! Connecting a Modbus RTU context
+
 use super::*;
 
 use crate::service;

--- a/src/client/sync/mod.rs
+++ b/src/client/sync/mod.rs
@@ -5,7 +5,8 @@ pub mod rtu;
 pub mod tcp;
 
 use super::{
-    Client as AsyncClient, Context as AsyncContext, SlaveContext, Reader as AsyncReader, Writer as AsyncWriter,
+    Client as AsyncClient, Context as AsyncContext, Reader as AsyncReader, SlaveContext,
+    Writer as AsyncWriter,
 };
 
 use crate::frame::*;

--- a/src/client/sync/mod.rs
+++ b/src/client/sync/mod.rs
@@ -1,3 +1,5 @@
+//! Synchronous Modbus context access
+
 #[cfg(feature = "rtu")]
 pub mod rtu;
 

--- a/src/client/tcp.rs
+++ b/src/client/tcp.rs
@@ -1,3 +1,5 @@
+//! Connecting a Modbus TCP context
+
 use super::*;
 
 use crate::service;

--- a/src/client/util.rs
+++ b/src/client/util.rs
@@ -7,26 +7,20 @@ use std::{cell::RefCell, io::Error, rc::Rc};
 /// Helper for sharing a context between multiple clients,
 /// i.e. when addressing multiple slave devices in turn.
 #[derive(Default)]
-pub struct SharedContext {
+struct SharedContextHolder {
     context: Option<Rc<RefCell<Context>>>,
 }
 
-impl SharedContext {
+impl SharedContextHolder {
     /// Create an instance by wrapping an initial, optional context.
-    pub fn new(initial_context: Option<Context>) -> Self {
+    fn new(initial_context: Option<Context>) -> Self {
         Self {
             context: initial_context.map(RefCell::new).map(Rc::new),
         }
     }
 
-    /// Check if the instance is connected, i.e. if it wraps some
-    /// shared context reference.
-    pub fn is_connected(&self) -> bool {
-        self.context.is_some()
-    }
-
     /// Disconnect and drop the wrapped context reference.
-    pub fn disconnect(&mut self) -> impl Future<Item = (), Error = Error> {
+    fn disconnect(&mut self) -> impl Future<Item = (), Error = Error> {
         if let Some(context) = self.context.take() {
             future::Either::A(context.borrow().disconnect())
         } else {
@@ -35,65 +29,82 @@ impl SharedContext {
     }
 
     /// Reconnect by replacing the wrapped context reference.
-    pub fn reconnect(&mut self, context: Context) {
+    fn reconnect(&mut self, context: Context) {
         self.context = Some(Rc::new(RefCell::new(context)));
     }
 
-    /// Obtain a shared reference of the wrapped context.
-    ///
-    /// The result should only be used for subsequent requests and must
-    /// not be stored. If the `SharedContext` itself is shared it might
-    /// get disconnected at any time!
-    pub fn share(&self) -> Result<Rc<RefCell<Context>>, Error> {
-        if let Some(ref context) = self.context {
-            Ok(Rc::clone(context))
-        } else {
-            Err(Error::new(ErrorKind::NotConnected, "No context"))
-        }
+    pub fn is_connected(&self) -> bool {
+        self.context.is_some()
+    }
+
+    fn share_context(&self) -> Option<Rc<RefCell<Context>>> {
+        self.context.as_ref().map(Rc::clone)
     }
 }
 
-/// Factory trait for creating a new context.
+/// Trait for (re-)creating new contexts on demand.
 pub trait NewContext {
+    /// Create a new context.
     fn new_context(&self) -> Box<dyn Future<Item = Context, Error = Error>>;
 }
 
 /// Reconnectable environment with a shared context.
-pub struct SharedEnvironment {
-    shared_context: SharedContext,
+pub struct SharedContext {
+    shared_context: SharedContextHolder,
     new_context: Box<dyn NewContext>,
 }
 
-impl SharedEnvironment {
+impl SharedContext {
+    /// Create a new instance with an optional, initial context and
+    /// a trait object for reconnecting the shared context on demand.
     pub fn new(inital_context: Option<Context>, new_context: Box<dyn NewContext>) -> Self {
         Self {
-            shared_context: SharedContext::new(inital_context),
+            shared_context: SharedContextHolder::new(inital_context),
             new_context,
         }
     }
 
-    pub fn shared_context(&self) -> Result<Rc<RefCell<Context>>, Error> {
-        self.shared_context.share()
+    pub fn is_connected(&self) -> bool {
+        self.shared_context.is_connected()
+    }
+
+    /// Try to obtain a shared context reference. The result will
+    /// be `None` if no context is available, i.e. if the shared
+    /// context is not connected.
+    ///
+    /// The result should only be used temporarily for the next
+    /// asynchronous request and must not be reused later!
+    pub fn share_context(&self) -> Option<Rc<RefCell<Context>>> {
+        self.shared_context.share_context()
     }
 }
 
+/// Asynchronously (disconnect and) reconnect the shared context.
 pub fn reconnect_shared_context(
-    shared_env: &Rc<RefCell<SharedEnvironment>>,
+    shared_context: &Rc<RefCell<SharedContext>>,
 ) -> impl Future<Item = (), Error = Error> {
-    let disconnected_env = Rc::clone(shared_env);
-    shared_env
+    let disconnected_context = Rc::clone(shared_context);
+    // The existing context needs to be disconnected first to
+    // release any resources that might be reused for the new
+    // context, i.e. a serial port with exclusive access.
+    shared_context
         .borrow_mut()
         .shared_context
         .disconnect()
         .and_then(move |()| {
-            debug_assert!(!disconnected_env.borrow().shared_context.is_connected());
-            let reconnected_env = Rc::clone(&disconnected_env);
-            disconnected_env
+            // After disconnecting the existing context create
+            // a new instance...
+            debug_assert!(!disconnected_context.borrow().is_connected());
+            let reconnected_context = Rc::clone(&disconnected_context);
+            disconnected_context
                 .borrow()
                 .new_context
                 .new_context()
                 .map(move |context| {
-                    reconnected_env
+                    // ...and put it into the shared context. The new
+                    // context will then be used for all subsequent
+                    // client requests.
+                    reconnected_context
                         .borrow_mut()
                         .shared_context
                         .reconnect(context)

--- a/src/client/util.rs
+++ b/src/client/util.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+use futures::{future, Future};
+
+use std::{cell::RefCell, io::Error, rc::Rc};
+
+/// Helper for sharing a context between multiple clients,
+/// i.e. when addressing multiple slave devices in turn.
+#[derive(Default)]
+pub struct SharedContext {
+    context: Option<Rc<RefCell<Context>>>,
+}
+
+impl SharedContext {
+    /// Create an instance by wrapping an initial, optional context.
+    pub fn new(initial_context: Option<Context>) -> Self {
+        Self {
+            context: initial_context.map(RefCell::new).map(Rc::new),
+        }
+    }
+
+    /// Check if the instance is connected, i.e. if it wraps some
+    /// shared context reference.
+    pub fn is_connected(&self) -> bool {
+        self.context.is_some()
+    }
+
+    /// Disconnect and drop the wrapped context reference.
+    pub fn disconnect(&mut self) -> impl Future<Item = (), Error = Error> {
+        if let Some(context) = self.context.take() {
+            future::Either::A(context.borrow().disconnect())
+        } else {
+            future::Either::B(future::ok(()))
+        }
+    }
+
+    /// Reconnect by replacing the wrapped context reference.
+    pub fn reconnect(&mut self, context: Context) {
+        self.context = Some(Rc::new(RefCell::new(context)));
+    }
+
+    /// Obtain a shared reference of the wrapped context.
+    ///
+    /// The result should only be used for subsequent requests and must
+    /// not be stored. If the `SharedContext` itself is shared it might
+    /// get disconnected at any time!
+    pub fn share(&self) -> Result<Rc<RefCell<Context>>, Error> {
+        if let Some(ref context) = self.context {
+            Ok(Rc::clone(context))
+        } else {
+            Err(Error::new(ErrorKind::NotConnected, "No context"))
+        }
+    }
+}
+
+/// Factory trait for creating a new context.
+pub trait NewContext {
+    fn new_context(&self) -> Box<dyn Future<Item = Context, Error = Error>>;
+}
+
+/// Reconnectable environment with a shared context.
+pub struct SharedEnvironment {
+    shared_context: SharedContext,
+    new_context: Box<dyn NewContext>,
+}
+
+impl SharedEnvironment {
+    pub fn new(inital_context: Option<Context>, new_context: Box<dyn NewContext>) -> Self {
+        Self {
+            shared_context: SharedContext::new(inital_context),
+            new_context,
+        }
+    }
+
+    pub fn shared_context(&self) -> Result<Rc<RefCell<Context>>, Error> {
+        self.shared_context.share()
+    }
+}
+
+pub fn reconnect_shared_context(
+    shared_env: &Rc<RefCell<SharedEnvironment>>,
+) -> impl Future<Item = (), Error = Error> {
+    let disconnected_env = Rc::clone(shared_env);
+    shared_env
+        .borrow_mut()
+        .shared_context
+        .disconnect()
+        .and_then(move |()| {
+            debug_assert!(!disconnected_env.borrow().shared_context.is_connected());
+            let reconnected_env = Rc::clone(&disconnected_env);
+            disconnected_env
+                .borrow()
+                .new_context
+                .new_context()
+                .map(move |context| {
+                    reconnected_env
+                        .borrow_mut()
+                        .shared_context
+                        .reconnect(context)
+                })
+        })
+}

--- a/src/client/util.rs
+++ b/src/client/util.rs
@@ -1,3 +1,5 @@
+//! Utilities for sharing a Modbus context
+
 use super::*;
 
 use futures::{future, Future};
@@ -43,6 +45,8 @@ impl SharedContextHolder {
 }
 
 /// Trait for (re-)creating new contexts on demand.
+///
+/// Implement this trait for reconnecting a `SharedContext` on demand.
 pub trait NewContext {
     /// Create a new context.
     fn new_context(&self) -> Box<dyn Future<Item = Context, Error = Error>>;
@@ -64,13 +68,14 @@ impl SharedContext {
         }
     }
 
+    /// Checks if a shared context is available.
     pub fn is_connected(&self) -> bool {
         self.shared_context.is_connected()
     }
 
-    /// Try to obtain a shared context reference. The result will
-    /// be `None` if no context is available, i.e. if the shared
-    /// context is not connected.
+    /// Try to obtain a shared context reference. The result is `None`
+    /// if no context is available, i.e. if the shared context is not
+    /// connected.
     ///
     /// The result should only be used temporarily for the next
     /// asynchronous request and must not be reused later!


### PR DESCRIPTION
A follow-up for the disconnect workaround. For a first use case of the client utilities please refer to the example in https://github.com/slowtec/truebner-smt100/tree/shared_context.