### PR TITLE
Add libudev feature to enable/disable tokio-serial/libudev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,17 @@ tokio-codec = "0.1"
 tokio-proto = "0.1"
 tokio-service = "0.1"
 
+# Disable default-features to exclude unused dependency on libudev
 tokio-serial = { version = "3.2", optional = true, default-features = false }
 
 [dev-dependencies]
 env_logger = "0.6"
 
 [features]
-default = ["tcp", "rtu", "sync", "libudev"]
+default = ["tcp", "rtu", "sync"]
 rtu = ["tokio-serial"]
 tcp = []
 sync = []
-libudev = ["tokio-serial/libudev"]
 
 [badges]
 travis-ci = { repository = "slowtec/tokio-modbus" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,17 @@ tokio-codec = "0.1"
 tokio-proto = "0.1"
 tokio-service = "0.1"
 
-tokio-serial = { version = "3.2", optional = true }
+tokio-serial = { version = "3.2", optional = true, default-features = false }
 
 [dev-dependencies]
 env_logger = "0.6"
 
 [features]
-default = ["tcp", "rtu", "sync"]
+default = ["tcp", "rtu", "sync", "libudev"]
 rtu = ["tokio-serial"]
 tcp = []
 sync = []
+libudev = ["tokio-serial/libudev"]
 
 [badges]
 travis-ci = { repository = "slowtec/tokio-modbus" }


### PR DESCRIPTION
When trying to cross-compile this crate for a Raspberry Pi
(`armv7-unknown-linux-gnueabihf`), the libudev dependency of tokio-serial
failed to build.

I considered two ways of addressing this: Either set up proper
cross-compilation for libudev, or remove it as a dependency. I tried the
latter, and it appears that libudev is not needed as a dependency in
this project.