### PR TITLE
Implement disconnect() for TCP clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.5 (2019-09-17)
+
+- Added missing implementation of `disconnect()` for TCP clients
+- Upgraded *tokio-serial* to version 3.3
+
 ## v0.3.4 (2019-05-21)
 
 - Disabled the default features of *tokio-serial* to exclude an unused

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-modbus"
 description = "Tokio-based Modbus library"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["slowtec GmbH", "Markus Kohlhase <markus.kohlhase@slowtec.de>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tokio-proto = "0.1"
 tokio-service = "0.1"
 
 # Disable default-features to exclude unused dependency on libudev
-tokio-serial = { version = "3.2", optional = true, default-features = false }
+tokio-serial = { version = "3.3", optional = true, default-features = false }
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -120,7 +120,7 @@ fn get_request_pdu_len(adu_buf: &BytesMut) -> Result<Option<usize>> {
     }
     let fn_code = adu_buf[1];
     let len = match fn_code {
-        0x01...0x06 => Some(5),
+        0x01..=0x06 => Some(5),
         0x07 | 0x0B | 0x0C | 0x11 => Some(1),
         0x0F | 0x10 => {
             if adu_buf.len() > 4 {
@@ -156,7 +156,7 @@ fn get_response_pdu_len(adu_buf: &BytesMut) -> Result<Option<usize>> {
     }
     let fn_code = adu_buf[1];
     let len = match fn_code {
-        0x01...0x04 | 0x0C | 0x17 => {
+        0x01..=0x04 | 0x0C | 0x17 => {
             if adu_buf.len() > 2 {
                 Some(2 + adu_buf[2] as usize)
             } else {
@@ -175,7 +175,7 @@ fn get_response_pdu_len(adu_buf: &BytesMut) -> Result<Option<usize>> {
                 None
             }
         }
-        0x81...0xAB => Some(2),
+        0x81..=0xAB => Some(2),
         _ => {
             return Err(Error::new(
                 ErrorKind::InvalidData,
@@ -676,7 +676,7 @@ mod tests {
 
         #[test]
         fn decode_rtu_response_drop_invalid_bytes() {
-            let _ = env_logger::init();
+            env_logger::init();
             let mut codec = ClientCodec::default();
             let mut buf = BytesMut::from(vec![
                 0x42, // dropped byte

--- a/src/codec/tcp.rs
+++ b/src/codec/tcp.rs
@@ -44,6 +44,7 @@ impl Decoder for AduDecoder {
     type Item = (Header, Bytes);
     type Error = Error;
 
+    #[allow(clippy::assertions_on_constants)]
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<(Header, Bytes)>> {
         if buf.len() < HEADER_LEN {
             return Ok(None);
@@ -184,7 +185,7 @@ mod tests {
         const TRANSACTION_ID_LO: u8 = 0x01;
 
         const PROTOCOL_ID_HI: u8 = (PROTOCOL_ID >> 8) as u8;
-        const PROTOCOL_ID_LO: u8 = PROTOCOL_ID as u8 & 0xFF;
+        const PROTOCOL_ID_LO: u8 = (PROTOCOL_ID & 0xFF) as u8;
 
         const UNIT_ID: UnitId = 0xFE;
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -9,7 +9,12 @@ use std::{error, fmt};
 /// A Modbus function code is represented by an unsigned 8 bit integer.
 pub(crate) type FunctionCode = u8;
 
-/// A Modbus address is represented by 16 bit (from `0` to `65535`).
+/// A Modbus protocol address is represented by 16 bit from `0` to `65535`.
+///
+/// This *protocol address* uses 0-based indexing, while the *coil address* or
+/// *register address* is often specified as a number with 1-based indexing.
+/// Please consult the specification of your devices if 1-based coil/register
+/// addresses need to be converted to 0-based protocol addresses by subtracting 1.
 pub(crate) type Address = u16;
 
 /// A Coil represents a single bit.

--- a/src/frame/tcp.rs
+++ b/src/frame/tcp.rs
@@ -13,6 +13,7 @@ pub(crate) struct Header {
 pub(crate) struct RequestAdu {
     pub hdr: Header,
     pub pdu: RequestPdu,
+    pub disconnect: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -30,7 +30,7 @@ where
     type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error>>;
 
     fn call(&self, adu: Self::Request) -> Self::Future {
-        let Self::Request { hdr, pdu } = adu;
+        let Self::Request { hdr, pdu, .. } = adu;
         let req: Request = pdu.into();
         Box::new(self.service.call(req.into()).then(move |rsp| match rsp {
             Ok(rsp) => {
@@ -114,7 +114,11 @@ mod tests {
             unit_id: 7,
         };
         let pdu = Request::ReadInputRegisters(0, 1).into();
-        let req_adu = RequestAdu { hdr, pdu };
+        let req_adu = RequestAdu {
+            hdr,
+            pdu,
+            disconnect: false,
+        };
         let rsp_adu = service.call(req_adu).wait().unwrap();
 
         assert_eq!(

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -56,18 +56,20 @@ impl Context {
         }
     }
 
-    fn next_request_adu<R>(&self, req: R) -> RequestAdu
+    fn next_request_adu<R>(&self, req: R, disconnect: bool) -> RequestAdu
     where
         R: Into<RequestPdu>,
     {
         RequestAdu {
             hdr: self.next_request_hdr(self.unit_id),
             pdu: req.into(),
+            disconnect,
         }
     }
 
     pub fn call(&self, req: Request) -> impl Future<Item = Response, Error = Error> {
-        let req_adu = self.next_request_adu(req);
+        let disconnect = req == Request::Disconnect;
+        let req_adu = self.next_request_adu(req, disconnect);
         let req_hdr = req_adu.hdr;
         self.service
             .call(req_adu)


### PR DESCRIPTION
First attempt to fix #33.

The TCP implementation for the `disconnect()` request that drops connections by inserting a *poison pill* was missing. We needed this to get rid of exclusive connections to the serial port that got stale sometimes.

Unfortunately, TCP connections are not closed immediately but remain in TIME_WAIT for some time, before they disappear.