### PR TITLE
[WIP] Issue 40: read device identification

### DIFF
--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -11,6 +11,7 @@ use byteorder::{BigEndian, ReadBytesExt};
 use bytes::{BufMut, Bytes, BytesMut};
 use std::convert::{TryFrom, TryInto};
 use std::io::{self, Cursor, Error, ErrorKind};
+use std::str::from_utf8;
 
 impl From<Request> for Bytes {
     fn from(req: Request) -> Bytes {
@@ -132,6 +133,8 @@ impl From<Response> for Bytes {
                 data.put_u8(conformity_level);
                 data.put_u8(if more_follows { 0xff } else { 0x00 });
                 data.put_u8(next_object_id);
+                /* TODO: do not panic! */
+                data.put_u8(device_id_objects.len().try_into().unwrap());
                 for dio in device_id_objects {
                     data.put_u8(dio.id);
                     data.put_u8(dio.value.bytes().len().try_into().unwrap());
@@ -317,6 +320,36 @@ impl TryFrom<Bytes> for Response {
                     data.push(rdr.read_u16::<BigEndian>()?);
                 }
                 ReadWriteMultipleRegisters(data)
+            }
+            0x2b if rdr.read_u8()? == 0x0e => {
+                let read_dev_id_code = rdr.read_u8()?;
+                let conformity_level = rdr.read_u8()?;
+                let more_follows = rdr.read_u8()? == 0xff;
+                let next_object_id = rdr.read_u8()?;
+                let count = rdr.read_u8()?;
+                let mut objects = vec![];
+                for _ in 0..count {
+                    let id = rdr.read_u8()?;
+                    let len = rdr.read_u8()?;
+                    let mut ascii = vec![];
+                    for _ in 0..len {
+                        ascii.push(rdr.read_u8()?);
+                    }
+                    let value = match from_utf8(&ascii) {
+                        Ok(v) => v.to_string(),
+                        Err(_) => {
+                            return Err(Error::new(ErrorKind::InvalidData, "Utf8 decode error"))
+                        }
+                    };
+                    objects.push(ReadDevIdObject { id, value });
+                }
+                ReadDeviceIdentification(
+                    read_dev_id_code,
+                    conformity_level,
+                    more_follows,
+                    next_object_id,
+                    objects,
+                )
             }
             _ => Custom(fn_code, bytes[1..].into()),
         };
@@ -548,10 +581,7 @@ mod tests {
             req_to_fn_code(&ReadWriteMultipleRegisters(0, 0, 0, vec![])),
             0x17
         );
-        assert_eq!(
-            req_to_fn_code(&ReadDeviceIdentification(1, 2)),
-            0x2b
-        );
+        assert_eq!(req_to_fn_code(&ReadDeviceIdentification(1, 2)), 0x2b);
         assert_eq!(req_to_fn_code(&Custom(88, vec![])), 88);
     }
 
@@ -567,7 +597,10 @@ mod tests {
         assert_eq!(rsp_to_fn_code(&WriteSingleRegister(0, 0)), 0x06);
         assert_eq!(rsp_to_fn_code(&WriteMultipleRegisters(0, 0)), 0x10);
         assert_eq!(rsp_to_fn_code(&ReadWriteMultipleRegisters(vec![])), 0x17);
-        assert_eq!(rsp_to_fn_code(&ReadDeviceIdentification(0, 0, false, 0, vec![])), 0x2b);
+        assert_eq!(
+            rsp_to_fn_code(&ReadDeviceIdentification(0, 0, false, 0, vec![])),
+            0x2b
+        );
         assert_eq!(rsp_to_fn_code(&Custom(99, vec![])), 99);
     }
 
@@ -1008,6 +1041,38 @@ mod tests {
         }
 
         #[test]
+        fn read_device_identification() {
+            let resp: Bytes = Response::ReadDeviceIdentification(
+                1,
+                1,
+                true,
+                0,
+                vec![
+                    ReadDevIdObject {
+                        id: 0,
+                        value: "Company identification".to_string(),
+                    },
+                    ReadDevIdObject {
+                        id: 1,
+                        value: "Product code XX".to_string(),
+                    },
+                    ReadDevIdObject {
+                        id: 2,
+                        value: "V2.11".to_string(),
+                    },
+                ],
+            )
+            .into();
+            let bytes = Bytes::from(vec![
+                0x2b, 0x0e, 0x01, 0x01, 0xff, 0x00, 0x03, 0x00, 0x16, 0x43, 0x6f, 0x6d, 0x70, 0x61,
+                0x6e, 0x79, 0x20, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74,
+                0x69, 0x6f, 0x6e, 0x01, 0x0f, 0x50, 0x72, 0x6f, 0x64, 0x75, 0x63, 0x74, 0x20, 0x63,
+                0x6f, 0x64, 0x65, 0x20, 0x58, 0x58, 0x02, 0x05, 0x56, 0x32, 0x2e, 0x31, 0x31,
+            ]);
+            assert_eq!(resp, bytes);
+        }
+
+        #[test]
         fn custom() {
             let bytes: Bytes = Response::Custom(0x55, vec![0xCC, 0x88, 0xAA, 0xFF]).into();
             assert_eq!(bytes[0], 0x55);
@@ -1094,6 +1159,40 @@ mod tests {
             let bytes = Bytes::from(vec![0x17, 0x02, 0x12, 0x34]);
             let rsp = Response::try_from(bytes).unwrap();
             assert_eq!(rsp, Response::ReadWriteMultipleRegisters(vec![0x1234]));
+        }
+
+        #[test]
+        fn read_device_identification() {
+            let bytes = Bytes::from(vec![
+                0x2b, 0x0e, 0x01, 0x01, 0x00, 0x00, 0x03, 0x00, 0x16, 0x43, 0x6f, 0x6d, 0x70, 0x61,
+                0x6e, 0x79, 0x20, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74,
+                0x69, 0x6f, 0x6e, 0x01, 0x0f, 0x50, 0x72, 0x6f, 0x64, 0x75, 0x63, 0x74, 0x20, 0x63,
+                0x6f, 0x64, 0x65, 0x20, 0x58, 0x58, 0x02, 0x05, 0x56, 0x32, 0x2e, 0x31, 0x31,
+            ]);
+            let rsp = Response::try_from(bytes).unwrap();
+            assert_eq!(
+                rsp,
+                Response::ReadDeviceIdentification(
+                    1,
+                    1,
+                    false,
+                    0,
+                    vec![
+                        ReadDevIdObject {
+                            id: 0,
+                            value: "Company identification".to_string()
+                        },
+                        ReadDevIdObject {
+                            id: 1,
+                            value: "Product code XX".to_string()
+                        },
+                        ReadDevIdObject {
+                            id: 2,
+                            value: "V2.11".to_string()
+                        },
+                    ]
+                )
+            );
         }
 
         #[test]

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -29,6 +29,22 @@ pub(crate) type Word = u16;
 /// Number of items to process (`0` - `65535`).
 pub(crate) type Quantity = u16;
 
+pub(crate) type ReadDeviceIdCode = u8;
+
+pub(crate) type ObjectId = u8;
+
+pub(crate) type ConformityLevel = u8;
+
+pub(crate) type MoreFollows = bool;
+
+pub(crate) type NextObjectId = u8;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadDevIdObject {
+    pub id: u8,
+    pub value: String,
+}
+
 /// A request represents a message from the client (master) to the server (slave).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Request {
@@ -79,6 +95,8 @@ pub enum Request {
     /// The fourth parameter is the vector of values to write to the registers.
     ReadWriteMultipleRegisters(Address, Quantity, Address, Vec<Word>),
 
+    ReadDeviceIdentification(ReadDeviceIdCode, ObjectId),
+
     /// A raw modbus request.
     /// The first parameter is the modbus function code.
     /// The second parameter is the raw bytes of the request.
@@ -113,6 +131,13 @@ pub enum Response {
     WriteSingleRegister(Address, Word),
     WriteMultipleRegisters(Address, Quantity),
     ReadWriteMultipleRegisters(Vec<Word>),
+    ReadDeviceIdentification(
+        ReadDeviceIdCode,
+        ConformityLevel,
+        MoreFollows,
+        NextObjectId,
+        Vec<ReadDevIdObject>,
+    ),
     Custom(FunctionCode, Vec<u8>),
 }
 


### PR DESCRIPTION
Response and request de- and serialization is done, client api also. I would be grateful for review.

From my current understanding of the codebase the burden of creating server side logic for request processing is on the shoulders of user. In contrast to standard read-write registers functions this one is quite complicated. We have two options, both are not done for the moment:

1. implement all the logic for that function in the library, user task is to initialize the Service with HashMap<int, string> (objId -> value),

2. user handles segmentation and preparation of data, library checks if everything is ok (ascii is ascii, data fits in pdu and so on).

Personally i like option 1 more, but it seems that it doesn't match the 'spirit' of tokio-modbus. What are your thoughts about that?