### PR TITLE
Examples/rtu

### DIFF
--- a/examples/rtu-client-shared_context.rs
+++ b/examples/rtu-client-shared_context.rs
@@ -1,0 +1,76 @@
+#[cfg(feature = "rtu")]
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::{cell::RefCell, future::Future, io::Error, pin::Pin, rc::Rc};
+
+    use tokio_modbus::client::{
+        rtu,
+        util::{reconnect_shared_context, NewContext, SharedContext},
+        Context,
+    };
+    use tokio_modbus::prelude::*;
+    use tokio_serial::{Serial, SerialPortSettings};
+
+    const SLAVE_1: Slave = Slave(0x01);
+    const SLAVE_2: Slave = Slave(0x02);
+
+    #[derive(Debug)]
+    struct SerialConfig {
+        path: String,
+        settings: SerialPortSettings,
+    }
+
+    impl NewContext for SerialConfig {
+        fn new_context(&self) -> Pin<Box<dyn Future<Output = Result<Context, Error>>>> {
+            let serial = Serial::from_path(&self.path, &self.settings);
+            Box::pin(async {
+                let port = serial?;
+                rtu::connect(port).await
+            })
+        }
+    }
+
+    let serial_config = SerialConfig {
+        path: "/dev/ttyUSB0".into(),
+        settings: SerialPortSettings {
+            baud_rate: 19200,
+            ..Default::default()
+        },
+    };
+    println!("Configuration: {:?}", serial_config);
+
+    // A shared, reconnectable context is not actually needed in this
+    // simple example. Nevertheless we use it here to demonstrate how
+    // it works.
+    let shared_context = Rc::new(RefCell::new(SharedContext::new(
+        None, // no initial context, i.e. not connected
+        Box::new(serial_config),
+    )));
+
+    // Reconnect for connecting an initial context
+    reconnect_shared_context(&shared_context).await?;
+
+    assert!(shared_context.borrow().is_connected());
+    println!("Connected");
+
+    println!("Reading a sensor value from {:?}", SLAVE_1);
+    let context = shared_context.borrow().share_context().unwrap();
+    let mut context = context.borrow_mut();
+    context.set_slave(SLAVE_1);
+    let response = context.read_holding_registers(0x082B, 2).await?;
+    println!("Sensor value for device {:?} is: {:?}", SLAVE_1, response);
+
+    println!("Reading a sensor value from {:?}", SLAVE_2);
+    context.set_slave(SLAVE_2);
+    let response = context.read_holding_registers(0x082B, 2).await?;
+
+    println!("Sensor value for device {:?} is: {:?}", SLAVE_2, response);
+
+    Ok(())
+}
+
+#[cfg(not(feature = "rtu"))]
+pub fn main() {
+    println!("feature `rtu` is required to run this example");
+    std::process::exit(1);
+}

--- a/examples/rtu-client.rs
+++ b/examples/rtu-client.rs
@@ -1,70 +1,21 @@
 #[cfg(feature = "rtu")]
 #[tokio::main]
-pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use std::{cell::RefCell, future::Future, io::Error, pin::Pin, rc::Rc};
-
-    use tokio_modbus::client::{
-        rtu,
-        util::{reconnect_shared_context, NewContext, SharedContext},
-        Context,
-    };
-    use tokio_modbus::prelude::*;
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use tokio_serial::{Serial, SerialPortSettings};
 
-    const SLAVE_1: Slave = Slave(0x01);
-    const SLAVE_2: Slave = Slave(0x02);
+    use tokio_modbus::prelude::*;
 
-    #[derive(Debug)]
-    struct SerialConfig {
-        path: String,
-        settings: SerialPortSettings,
-    }
+    let tty_path = "/dev/ttyUSB0";
+    let slave = Slave(0x17);
 
-    impl NewContext for SerialConfig {
-        fn new_context(&self) -> Pin<Box<dyn Future<Output = Result<Context, Error>>>> {
-            let serial = Serial::from_path(&self.path, &self.settings);
-            Box::pin(async {
-                let port = serial?;
-                rtu::connect(port).await
-            })
-        }
-    }
+    let mut settings = SerialPortSettings::default();
+    settings.baud_rate = 19200;
+    let port = Serial::from_path(tty_path, &settings).unwrap();
 
-    let serial_config = SerialConfig {
-        path: "/dev/ttyUSB0".into(),
-        settings: SerialPortSettings {
-            baud_rate: 19200,
-            ..Default::default()
-        },
-    };
-    println!("Configuration: {:?}", serial_config);
-
-    // A shared, reconnectable context is not actually needed in this
-    // simple example. Nevertheless we use it here to demonstrate how
-    // it works.
-    let shared_context = Rc::new(RefCell::new(SharedContext::new(
-        None, // no initial context, i.e. not connected
-        Box::new(serial_config),
-    )));
-
-    // Reconnect for connecting an initial context
-    reconnect_shared_context(&shared_context).await?;
-
-    assert!(shared_context.borrow().is_connected());
-    println!("Connected");
-
-    println!("Reading a sensor value from {:?}", SLAVE_1);
-    let context = shared_context.borrow().share_context().unwrap();
-    let mut context = context.borrow_mut();
-    context.set_slave(SLAVE_1);
-    let response = context.read_holding_registers(0x082B, 2).await?;
-    println!("Sensor value for device {:?} is: {:?}", SLAVE_1, response);
-
-    println!("Reading a sensor value from {:?}", SLAVE_2);
-    context.set_slave(SLAVE_2);
-    let response = context.read_holding_registers(0x082B, 2).await?;
-
-    println!("Sensor value for device {:?} is: {:?}", SLAVE_2, response);
+    let mut ctx = rtu::connect_slave(port, slave).await?;
+    println!("Reading a sensor value");
+    let rsp = ctx.read_holding_registers(0x082B, 2).await?;
+    println!("Sensor value is: {:?}", rsp);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,6 @@
 //! #[cfg(feature = "rtu")]
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     use std::future::Future;
-//!     use tokio::runtime::Runtime;
 //!     use tokio_serial::{Serial, SerialPortSettings};
 //!
 //!     use tokio_modbus::prelude::*;


### PR DESCRIPTION
I've shorten the 'rtu-client' example by using the brilliant example from the lib documentation (shorten that example as well a little). The "old" example was a little hard to get from a 'new user' perspective, with all the new async/ .await stuff on top of tokio.

The "old" more complex 'rtu-client' example was restored under a new name.