### PR TITLE
WIP: handle no response for broadcast

### DIFF
--- a/examples/tcp-client-custom-fn.rs
+++ b/examples/tcp-client-custom-fn.rs
@@ -11,7 +11,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rsp = ctx.call(Request::Custom(0x66, vec![0x11, 0x42])).await?;
 
     match rsp {
-        Response::Custom(f, rsp) => {
+        Some(Response::Custom(f, rsp)) => {
             println!("Result for function {} is '{:?}'", f, rsp);
         }
         _ => {

--- a/src/client/sync/mod.rs
+++ b/src/client/sync/mod.rs
@@ -18,7 +18,7 @@ use std::io::Result;
 
 /// A transport independent synchronous client trait.
 pub trait Client: SlaveContext {
-    fn call(&mut self, req: Request) -> Result<Response>;
+    fn call(&mut self, req: Request) -> Result<Option<Response>>;
 }
 
 /// A transport independent synchronous reader trait.
@@ -51,7 +51,7 @@ pub struct Context {
 }
 
 impl Client for Context {
-    fn call(&mut self, req: Request) -> Result<Response> {
+    fn call(&mut self, req: Request) -> Result<Option<Response>> {
         self.core.block_on(self.async_ctx.call(req))
     }
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -138,7 +138,9 @@ impl From<ExceptionResponse> for Bytes {
 impl From<ResponsePdu> for Bytes {
     fn from(pdu: ResponsePdu) -> Bytes {
         // TODO: Replace with Result::map_or_else() when available
-        pdu.0.map(Into::into).unwrap_or_else(Into::into)
+        pdu.0
+            .map(|opt| opt.expect("Response can not be None").into())
+            .unwrap_or_else(Into::into)
     }
 }
 

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -676,7 +676,7 @@ mod tests {
             let ResponseAdu { hdr, pdu } = codec.decode(&mut buf).unwrap().unwrap();
             assert_eq!(buf.len(), 1);
             assert_eq!(hdr.slave_id, 0x01);
-            if let Ok(Response::ReadHoldingRegisters(data)) = pdu.into() {
+            if let Ok(Some(Response::ReadHoldingRegisters(data))) = pdu.into() {
                 assert_eq!(data.len(), 2);
                 assert_eq!(data, vec![0x8902, 0x42C7]);
             } else {
@@ -707,7 +707,7 @@ mod tests {
             let ResponseAdu { hdr, pdu } = codec.decode(&mut buf).unwrap().unwrap();
             assert_eq!(buf.len(), 1);
             assert_eq!(hdr.slave_id, 0x01);
-            if let Ok(Response::ReadHoldingRegisters(data)) = pdu.into() {
+            if let Ok(Some(Response::ReadHoldingRegisters(data))) = pdu.into() {
                 assert_eq!(data.len(), 2);
                 assert_eq!(data, vec![0x8902, 0x42C7]);
             } else {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -173,11 +173,11 @@ impl From<RequestPdu> for Request {
 
 /// Represents a message from the server (slave) to the client (master).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ResponsePdu(pub(crate) Result<Response, ExceptionResponse>);
+pub(crate) struct ResponsePdu(pub(crate) Result<Option<Response>, ExceptionResponse>);
 
 impl From<Response> for ResponsePdu {
     fn from(from: Response) -> Self {
-        ResponsePdu(Ok(from))
+        ResponsePdu(Ok(Some(from)))
     }
 }
 
@@ -187,13 +187,13 @@ impl From<ExceptionResponse> for ResponsePdu {
     }
 }
 
-impl From<Result<Response, ExceptionResponse>> for ResponsePdu {
-    fn from(from: Result<Response, ExceptionResponse>) -> Self {
+impl From<Result<Option<Response>, ExceptionResponse>> for ResponsePdu {
+    fn from(from: Result<Option<Response>, ExceptionResponse>) -> Self {
         ResponsePdu(from.map(Into::into).map_err(Into::into))
     }
 }
 
-impl From<ResponsePdu> for Result<Response, ExceptionResponse> {
+impl From<ResponsePdu> for Result<Option<Response>, ExceptionResponse> {
     fn from(from: ResponsePdu) -> Self {
         from.0
     }

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -51,7 +51,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + 'static> Context<T> {
         }
     }
 
-    async fn call(&mut self, req: Request) -> Result<Response, Error> {
+    async fn call(&mut self, req: Request) -> Result<Option<Response>, Error> {
         let disconnect = req == Request::Disconnect;
         let req_adu = self.next_request_adu(req, disconnect);
         let req_hdr = req_adu.hdr;
@@ -89,7 +89,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send + 'static> Client for Context<T> {
     fn call<'a>(
         &'a mut self,
         req: Request,
-    ) -> Pin<Box<dyn Future<Output = Result<Response, Error>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Response>, Error>> + Send + 'a>> {
         Box::pin(self.call(req))
     }
 }

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -75,7 +75,7 @@ impl Context {
         }
     }
 
-    pub async fn call(&mut self, req: Request) -> Result<Response, Error> {
+    pub async fn call(&mut self, req: Request) -> Result<Option<Response>, Error> {
         log::debug!("Call {:?}", req);
         let disconnect = req == Request::Disconnect;
         let req_adu = self.next_request_adu(req, disconnect);
@@ -118,7 +118,7 @@ impl Client for Context {
     fn call<'a>(
         &'a mut self,
         req: Request,
-    ) -> Pin<Box<dyn Future<Output = Result<Response, Error>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Response>, Error>> + Send + 'a>> {
         Box::pin(Context::call(self, req))
     }
 }


### PR DESCRIPTION
Sending a broadcast command should result in a None response instead of panicking. This switches `Result<Response>` to `Result<Option<Response>>` to handle this edge case.

I'm looking for feedback on this approach. Another approach could be splitting `call` into `call_with_response` and `call_without_response` to push the choice of broadcast/non-broadcast farther up to the client