### PR TITLE
Yet another Tokio v1 PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Cargo.lock
 
 # vi files
 *.swp
+
+# VS Code config files
+/.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,16 @@ smallvec = { version = "1", default-features = false }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 tokio-util = { version = "0.6", features = ["codec"] }
 # Disable default-features to exclude unused dependency on libudev
-serial-io = { version = "0.3", features = ["tokio"], optional = true, default-features = false }
+tokio-serial = { version = "5.4.0-beta1", optional = true, default-features = false }
 
 [dev-dependencies]
-env_logger = "0.7"
+env_logger = "0.9"
 futures = "0.3"
 tokio = { version = "1", features = ["net", "macros", "io-util"] }
 
 [features]
 default = ["tcp", "rtu", "sync"]
-rtu = ["serial-io", "futures-util/sink"]
+rtu = ["tokio-serial", "futures-util/sink"]
 tcp = ["tokio/net", "futures-util/sink"]
 sync = []
 server = ["net2", "futures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,27 +11,27 @@ repository = "https://github.com/slowtec/tokio-modbus"
 edition = "2018"
 
 [dependencies]
-bytes = "0.5"
+bytes = "1"
 byteorder = "1"
 futures = { version = "0.3", optional = true }
 futures-util = { version = "0.3", default-features = false }
 log = "0.4"
 net2 = { version = "0.2", optional = true, default-features = false }
 smallvec = { version = "1", default-features = false }
-# rt-core should be enabled only with "server" feature. Waiting for https://github.com/rust-lang/cargo/issues/5954
-tokio = { version = "0.2", features = ["rt-core"] }
-tokio-util = { version = "0.2", features = ["codec"] }
+# rt should be enabled only with "server" feature. Waiting for https://github.com/rust-lang/cargo/issues/5954
+tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
+tokio-util = { version = "0.6", features = ["codec"] }
 # Disable default-features to exclude unused dependency on libudev
-tokio-serial = { version = "4.3.3", optional = true, default-features = false }
+serial-io = { version = "0.3", features = ["tokio"], optional = true, default-features = false }
 
 [dev-dependencies]
 env_logger = "0.7"
 futures = "0.3"
-tokio = { version = "0.2", features = ["tcp", "macros", "io-util"] }
+tokio = { version = "1", features = ["net", "macros", "io-util"] }
 
 [features]
 default = ["tcp", "rtu", "sync"]
-rtu = ["tokio-serial", "futures-util/sink"]
+rtu = ["serial-io", "futures-util/sink"]
 tcp = ["tokio/net", "futures-util/sink"]
 sync = []
 server = ["net2", "futures"]
@@ -41,3 +41,38 @@ tcp-server-unstable = ["server"]
 travis-ci = { repository = "slowtec/tokio-modbus" }
 coveralls = { repository = "slowtec/tokio-modbus", branch = "master", service = "github" }
 maintenance = { status = "actively-developed" }
+
+[[example]]
+name = "rtu-client-shared-context"
+path = "examples/rtu-client-shared-context.rs"
+required-features = ["rtu"]
+
+[[example]]
+name = "rtu-client-sync"
+path = "examples/rtu-client-sync.rs"
+required-features = ["rtu", "sync"]
+
+[[example]]
+name = "rtu-client"
+path = "examples/rtu-client.rs"
+required-features = ["rtu"]
+
+[[example]]
+name = "tcp-client-custom-fn"
+path = "examples/tcp-client-custom-fn.rs"
+required-features = ["tcp"]
+
+[[example]]
+name = "tcp-client-sync"
+path = "examples/tcp-client-sync.rs"
+required-features = ["tcp", "sync"]
+
+[[example]]
+name = "tcp-client"
+path = "examples/tcp-client.rs"
+required-features = ["tcp"]
+
+[[example]]
+name = "tcp-server"
+path = "examples/tcp-server.rs"
+required-features = ["tcp", "server", "tcp-server-unstable"]

--- a/examples/rtu-client-shared-context.rs
+++ b/examples/rtu-client-shared-context.rs
@@ -2,13 +2,13 @@
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use std::{cell::RefCell, future::Future, io::Error, pin::Pin, rc::Rc};
 
-    use serial_io::{build, AsyncSerial, SerialPortBuilder};
     use tokio_modbus::client::{
         rtu,
         util::{reconnect_shared_context, NewContext, SharedContext},
         Context,
     };
     use tokio_modbus::prelude::*;
+    use tokio_serial::{SerialPortBuilder, SerialStream};
 
     const SLAVE_1: Slave = Slave(0x01);
     const SLAVE_2: Slave = Slave(0x02);
@@ -20,7 +20,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     impl NewContext for SerialConfig {
         fn new_context(&self) -> Pin<Box<dyn Future<Output = Result<Context, Error>>>> {
-            let serial = AsyncSerial::from_builder(&self.builder);
+            let serial = SerialStream::open(&self.builder);
             Box::pin(async {
                 let port = serial?;
                 rtu::connect(port).await
@@ -29,7 +29,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let serial_config = SerialConfig {
-        builder: build("/dev/ttyUSB0", 19200),
+        builder: tokio_serial::new("/dev/ttyUSB0", 19200),
     };
     println!("Configuration: {:?}", serial_config);
 

--- a/examples/rtu-client-sync.rs
+++ b/examples/rtu-client-sync.rs
@@ -1,12 +1,10 @@
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use serial_io::build;
-
     use tokio_modbus::prelude::*;
 
     let tty_path = "/dev/ttyUSB0";
     let slave = Slave(0x17);
 
-    let builder = build(tty_path, 19200);
+    let builder = tokio_serial::new(tty_path, 19200);
 
     let mut ctx = sync::rtu::connect_slave(&builder, slave)?;
     println!("Reading a sensor value");

--- a/examples/rtu-client-sync.rs
+++ b/examples/rtu-client-sync.rs
@@ -1,0 +1,17 @@
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use serial_io::build;
+
+    use tokio_modbus::prelude::*;
+
+    let tty_path = "/dev/ttyUSB0";
+    let slave = Slave(0x17);
+
+    let builder = build(tty_path, 19200);
+
+    let mut ctx = sync::rtu::connect_slave(&builder, slave)?;
+    println!("Reading a sensor value");
+    let rsp = ctx.read_holding_registers(0x082B, 2)?;
+    println!("Sensor value is: {:?}", rsp);
+
+    Ok(())
+}

--- a/examples/rtu-client.rs
+++ b/examples/rtu-client.rs
@@ -1,16 +1,14 @@
-#[cfg(feature = "rtu")]
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use tokio_serial::{Serial, SerialPortSettings};
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use serial_io::{build, AsyncSerial};
 
     use tokio_modbus::prelude::*;
 
     let tty_path = "/dev/ttyUSB0";
     let slave = Slave(0x17);
 
-    let mut settings = SerialPortSettings::default();
-    settings.baud_rate = 19200;
-    let port = Serial::from_path(tty_path, &settings).unwrap();
+    let builder = build(tty_path, 19200);
+    let port = AsyncSerial::from_builder(&builder).unwrap();
 
     let mut ctx = rtu::connect_slave(port, slave).await?;
     println!("Reading a sensor value");
@@ -18,10 +16,4 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Sensor value is: {:?}", rsp);
 
     Ok(())
-}
-
-#[cfg(not(feature = "rtu"))]
-pub fn main() {
-    println!("feature `rtu` is required to run this example");
-    std::process::exit(1);
 }

--- a/examples/rtu-client.rs
+++ b/examples/rtu-client.rs
@@ -1,14 +1,14 @@
 #[tokio::main(flavor = "current_thread")]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use serial_io::{build, AsyncSerial};
+    use tokio_serial::SerialStream;
 
     use tokio_modbus::prelude::*;
 
     let tty_path = "/dev/ttyUSB0";
     let slave = Slave(0x17);
 
-    let builder = build(tty_path, 19200);
-    let port = AsyncSerial::from_builder(&builder).unwrap();
+    let builder = tokio_serial::new(tty_path, 19200);
+    let port = SerialStream::open(&builder).unwrap();
 
     let mut ctx = rtu::connect_slave(port, slave).await?;
     println!("Reading a sensor value");

--- a/examples/tcp-client-custom-fn.rs
+++ b/examples/tcp-client-custom-fn.rs
@@ -1,5 +1,4 @@
-#[cfg(feature = "tcp")]
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use tokio_modbus::prelude::*;
 
@@ -15,15 +14,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Result for function {} is '{:?}'", f, rsp);
         }
         _ => {
-            panic!("unexpeted result");
+            panic!("unexpected result");
         }
     }
 
     Ok(())
-}
-
-#[cfg(not(feature = "tcp"))]
-pub fn main() {
-    println!("feature `tcp` is required to run this example");
-    std::process::exit(1);
 }

--- a/examples/tcp-client.rs
+++ b/examples/tcp-client.rs
@@ -1,5 +1,4 @@
-#[cfg(feature = "tcp")]
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use tokio_modbus::prelude::*;
 
@@ -19,10 +18,4 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("The coupler ID is '{}'", id);
 
     Ok(())
-}
-
-#[cfg(not(feature = "tcp"))]
-pub fn main() {
-    println!("feature `tcp` is required to run this example");
-    std::process::exit(1);
 }

--- a/examples/tcp-server.rs
+++ b/examples/tcp-server.rs
@@ -1,5 +1,4 @@
-#[cfg(all(feature = "tcp", feature = "server"))]
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use futures::future;
     use std::{thread, time::Duration};
@@ -43,10 +42,4 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("The result is '{:?}'", rsp);
 
     Ok(())
-}
-
-#[cfg(not(all(feature = "tcp", feature = "server")))]
-pub fn main() {
-    println!("both `tcp` and `server` features is required to run this example");
-    std::process::exit(1);
 }

--- a/src/client/sync/rtu.rs
+++ b/src/client/sync/rtu.rs
@@ -3,22 +3,20 @@ use super::{Context, Result};
 use crate::client::rtu::connect_slave as async_connect_slave;
 use crate::slave::Slave;
 
-use tokio_serial::{Serial, SerialPortSettings};
+use serial_io::{AsyncSerial, SerialPortBuilder};
 
 /// Connect to no particular Modbus slave device for sending
 /// broadcast messages.
-pub fn connect(tty_path: &str, settings: &SerialPortSettings) -> Result<Context> {
-    connect_slave(tty_path, settings, Slave::broadcast())
+pub fn connect(builder: &SerialPortBuilder) -> Result<Context> {
+    connect_slave(builder, Slave::broadcast())
 }
 
 /// Connect to any kind of Modbus slave device.
-pub fn connect_slave(
-    tty_path: &str,
-    settings: &SerialPortSettings,
-    slave: Slave,
-) -> Result<Context> {
-    let mut rt = tokio::runtime::Runtime::new()?;
-    let serial = Serial::from_path(tty_path, settings)?;
+pub fn connect_slave(builder: &SerialPortBuilder, slave: Slave) -> Result<Context> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()?;
+    let serial = AsyncSerial::from_builder(builder).unwrap();
     let async_ctx = rt.block_on(async_connect_slave(serial, slave))?;
     let sync_ctx = Context {
         core: rt,

--- a/src/client/sync/rtu.rs
+++ b/src/client/sync/rtu.rs
@@ -3,7 +3,7 @@ use super::{Context, Result};
 use crate::client::rtu::connect_slave as async_connect_slave;
 use crate::slave::Slave;
 
-use serial_io::{AsyncSerial, SerialPortBuilder};
+use tokio_serial::{SerialPortBuilder, SerialStream};
 
 /// Connect to no particular Modbus slave device for sending
 /// broadcast messages.
@@ -16,7 +16,7 @@ pub fn connect_slave(builder: &SerialPortBuilder, slave: Slave) -> Result<Contex
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_io()
         .build()?;
-    let serial = AsyncSerial::from_builder(builder).unwrap();
+    let serial = SerialStream::open(builder).unwrap();
     let async_ctx = rt.block_on(async_connect_slave(serial, slave))?;
     let sync_ctx = Context {
         core: rt,

--- a/src/client/sync/tcp.rs
+++ b/src/client/sync/tcp.rs
@@ -13,7 +13,9 @@ pub fn connect(socket_addr: SocketAddr) -> Result<Context> {
 /// gateway that is forwarding messages to/from the corresponding unit identified
 /// by the slave parameter.
 pub fn connect_slave(socket_addr: SocketAddr, slave: Slave) -> Result<Context> {
-    let mut rt = tokio::runtime::Runtime::new()?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()?;
     let async_ctx = rt.block_on(async_connect_slave(socket_addr, slave))?;
     let sync_ctx = Context {
         core: rt,

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -462,8 +462,8 @@ mod tests {
 
     #[test]
     fn convert_coil_to_bool() {
-        assert_eq!(coil_to_bool(0xFF00).unwrap(), true);
-        assert_eq!(coil_to_bool(0x0000).unwrap(), false);
+        assert!(coil_to_bool(0xFF00).unwrap());
+        assert!(!coil_to_bool(0x0000).unwrap());
     }
 
     #[test]

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -343,8 +343,7 @@ impl Decoder for ServerCodec {
     }
 }
 
-impl Encoder for ClientCodec {
-    type Item = RequestAdu;
+impl Encoder<RequestAdu> for ClientCodec {
     type Error = Error;
 
     fn encode(&mut self, adu: RequestAdu, buf: &mut BytesMut) -> Result<()> {
@@ -369,8 +368,7 @@ impl Encoder for ClientCodec {
     }
 }
 
-impl Encoder for ServerCodec {
-    type Item = ResponseAdu;
+impl Encoder<ResponseAdu> for ServerCodec {
     type Error = Error;
 
     fn encode(&mut self, adu: ResponseAdu, buf: &mut BytesMut) -> Result<()> {

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -191,6 +191,9 @@ fn calc_crc(data: &[u8]) -> u16 {
     for x in data {
         crc ^= u16::from(*x);
         for _ in 0..8 {
+            // if we followed clippy's suggestion to move out the crc >>= 1, the condition may not be met any more
+            // the recommended action therefore makes no sense and it is better to allow this lint
+            #[allow(clippy::branches_sharing_code)]
             if (crc & 0x0001) != 0 {
                 crc >>= 1;
                 crc ^= 0xA001;

--- a/src/codec/tcp.rs
+++ b/src/codec/tcp.rs
@@ -128,8 +128,7 @@ impl Decoder for ServerCodec {
     }
 }
 
-impl Encoder for ClientCodec {
-    type Item = RequestAdu;
+impl Encoder<RequestAdu> for ClientCodec {
     type Error = Error;
 
     fn encode(&mut self, adu: RequestAdu, buf: &mut BytesMut) -> Result<()> {
@@ -154,8 +153,7 @@ impl Encoder for ClientCodec {
     }
 }
 
-impl Encoder for ServerCodec {
-    type Item = ResponseAdu;
+impl Encoder<ResponseAdu> for ServerCodec {
     type Error = Error;
 
     fn encode(&mut self, adu: ResponseAdu, buf: &mut BytesMut) -> Result<()> {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -79,8 +79,8 @@ pub enum Request {
     /// The fourth parameter is the vector of values to write to the registers.
     ReadWriteMultipleRegisters(Address, Quantity, Address, Vec<Word>),
 
-    /// A raw modbus request.
-    /// The first parameter is the modbus function code.
+    /// A raw Modbus request.
+    /// The first parameter is the Modbus function code.
     /// The second parameter is the raw bytes of the request.
     Custom(FunctionCode, Vec<u8>),
 
@@ -96,7 +96,7 @@ pub enum Request {
     Disconnect,
 }
 
-/// The data of a successfull request.
+/// The data of a successful request.
 ///
 /// ReadCoils/ReadDiscreteInputs: The length of the result Vec is always a
 /// multiple of 8. Only the values of the first bits/coils that have actually
@@ -104,15 +104,51 @@ pub enum Request {
 /// server implementation and those coils should be should be ignored.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Response {
+    /// Response to a ReadCoils request
+    /// The parameter contains the coil values that have been read
+    /// See also the note above regarding the vector length
     ReadCoils(Vec<Coil>),
+
+    /// Response to a ReadDiscreteInputs request
+    /// The parameter contains the discrete input values that have been read
+    /// See also the note above regarding the vector length
     ReadDiscreteInputs(Vec<Coil>),
+
+    /// Response to a WriteSingleCoil request
+    /// The first parameter contains the address of the coil that has been written to
+    /// The second parameter contains the value that has been written to the coil the given address
     WriteSingleCoil(Address, Coil),
+
+    /// Response to a WriteMultipleCoils request
+    /// The first parameter contains the address at the start of the range that has been written to
+    /// The second parameter contains the amount of values that have been written
     WriteMultipleCoils(Address, Quantity),
+
+    /// Response to a ReadInputRegisters request
+    /// The parameter contains the register values that have been read
     ReadInputRegisters(Vec<Word>),
+
+    /// Response to a ReadHoldingRegisters request
+    /// The parameter contains the register values that have been read
     ReadHoldingRegisters(Vec<Word>),
+
+    /// Response to a WriteSingleRegister request
+    /// The first parameter contains the address of the register that has been written to
+    /// The second parameter contains the value that has been written to the register at the given address
     WriteSingleRegister(Address, Word),
+
+    /// Response to a WriteMultipleRegisters request
+    /// The first parameter contains the address at the start of the register range that has been written to
+    /// The second parameter contains the amount of register that have been written
     WriteMultipleRegisters(Address, Quantity),
+
+    /// Response to a ReadWriteMultipleRegisters request
+    /// The parameter contains the register values that have been read as part of the read instruction
     ReadWriteMultipleRegisters(Vec<Word>),
+
+    /// Response to a raw Modbus request
+    /// The first parameter contains the returned Modbus function code
+    /// The second parameter contains the bytes read following the function code
     Custom(FunctionCode, Vec<u8>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,15 +91,15 @@
 //! # #[cfg(feature = "rtu")]
 //! #[tokio::main(flavor = "current_thread")]
 //! pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     use serial_io::{build, AsyncSerial};
+//!     use tokio_serial::SerialStream;
 //!
 //!     use tokio_modbus::prelude::*;
 //!
 //!     let tty_path = "/dev/ttyUSB0";
 //!     let slave = Slave(0x17);
 //!
-//!     let builder = build(tty_path, 19200);
-//!     let port = AsyncSerial::from_builder(&builder).unwrap();
+//!     let builder = tokio_serial::new(tty_path, 19200);
+//!     let port = SerialStream::open(&builder).unwrap();
 //!
 //!     let mut ctx = rtu::connect_slave(port, slave).await?;
 //!     println!("Reading a sensor value");
@@ -115,14 +115,12 @@
 //! ```rust,no_run
 //! # #[cfg(all(feature = "rtu", feature = "sync"))]
 //! pub fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     use serial_io::{build, AsyncSerial};
-//!
 //!     use tokio_modbus::prelude::*;
 //!
 //!     let tty_path = "/dev/ttyUSB0";
 //!     let slave = Slave(0x17);
 //!
-//!     let builder = build(tty_path, 19200);
+//!     let builder = tokio_serial::new(tty_path, 19200);
 //!
 //!     let mut ctx = sync::rtu::connect_slave(&builder, slave)?;
 //!     println!("Reading a sensor value");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,8 @@
 //! ## TCP client
 //!
 //! ```rust,no_run
-//! #[cfg(feature = "tcp")]
-//! #[tokio::main]
+//! # #[cfg(feature = "tcp")]
+//! #[tokio::main(flavor = "current_thread")]
 //! pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     use std::future::Future;
 //!     use tokio::runtime::Runtime;
@@ -71,7 +71,7 @@
 //! ## Sync TCP client
 //!
 //! ```rust,no_run
-//! #[cfg(all(feature = "tcp", feature = "sync"))]
+//! # #[cfg(all(feature = "tcp", feature = "sync"))]
 //! pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     use tokio_modbus::prelude::*;
 //!
@@ -88,23 +88,45 @@
 //! ## RTU client
 //!
 //! ```rust,no_run
-//! #[cfg(feature = "rtu")]
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     use tokio_serial::{Serial, SerialPortSettings};
+//! # #[cfg(feature = "rtu")]
+//! #[tokio::main(flavor = "current_thread")]
+//! pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     use serial_io::{build, AsyncSerial};
 //!
 //!     use tokio_modbus::prelude::*;
 //!
 //!     let tty_path = "/dev/ttyUSB0";
 //!     let slave = Slave(0x17);
 //!
-//!     let mut settings = SerialPortSettings::default();
-//!     settings.baud_rate = 19200;
-//!     let port = Serial::from_path(tty_path, &settings).unwrap();
+//!     let builder = build(tty_path, 19200);
+//!     let port = AsyncSerial::from_builder(&builder).unwrap();
 //!
 //!     let mut ctx = rtu::connect_slave(port, slave).await?;
 //!     println!("Reading a sensor value");
 //!     let rsp = ctx.read_holding_registers(0x082B, 2).await?;
+//!     println!("Sensor value is: {:?}", rsp);
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Sync RTU client
+//!
+//! ```rust,no_run
+//! # #[cfg(all(feature = "rtu", feature = "sync"))]
+//! pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     use serial_io::{build, AsyncSerial};
+//!
+//!     use tokio_modbus::prelude::*;
+//!
+//!     let tty_path = "/dev/ttyUSB0";
+//!     let slave = Slave(0x17);
+//!
+//!     let builder = build(tty_path, 19200);
+//!
+//!     let mut ctx = sync::rtu::connect_slave(&builder, slave)?;
+//!     println!("Reading a sensor value");
+//!     let rsp = ctx.read_holding_registers(0x082B, 2)?;
 //!     println!("Sensor value is: {:?}", rsp);
 //!
 //!     Ok(())

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, io, rc::Rc, sync::Arc};
 
-/// A modbus server service.
+/// A Modbus server service.
 pub trait Service {
     /// Requests handled by the service.
     type Request;

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -80,12 +80,15 @@ where
     S::Instance: 'static + Send + Sync,
     Sd: Future<Output = ()> + Unpin + Send + Sync + 'static,
 {
-    let mut rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_io()
+        .build()
+        .unwrap();
 
     let new_service = Arc::new(new_service);
 
     let server = async {
-        let mut listener = listener(&addr, workers).unwrap();
+        let listener = listener(&addr, workers).unwrap();
 
         loop {
             let (stream, _) = listener.accept().await?;
@@ -193,7 +196,7 @@ mod tests {
         #[derive(Clone)]
         struct DummyService {
             response: Response,
-        };
+        }
 
         impl Service for DummyService {
             type Request = Request;

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -71,7 +71,7 @@ impl Server {
     }
 }
 
-/// Will start a TCP listener and will serve data with service providen
+/// Will start a TCP listener and will serve data with service provided
 /// until shutdown signal will be triggered in shutdown_signal future
 fn serve_until<S, Sd>(addr: SocketAddr, workers: usize, new_service: S, shutdown_signal: Sd)
 where

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -105,7 +105,7 @@ mod tests {
         pin::Pin,
         task::{Context, Poll},
     };
-    use tokio::io::{AsyncRead, AsyncWrite, Result};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, Result};
 
     struct MockTransport;
 
@@ -117,9 +117,9 @@ mod tests {
             fn poll_read(
                 self: Pin<&mut Self>,
                 _: &mut Context,
-                _: &mut [u8],
-            ) -> Poll<Result<usize>> {
-                Poll::Ready(Ok(0))
+                _: &mut ReadBuf,
+            ) -> Poll<Result<()>> {
+                Poll::Ready(Ok(()))
             }
         }
 


### PR DESCRIPTION
Based on the PR from @Tarnadas but with `tokio_serial` added back in as a dependency instead of `serial-io` due to its incoming Windows pipes support (from https://github.com/berkowski/tokio-serial/pull/42 and earlier work).
Also homogenized and expanded a bit of documentation for a little bit.

Works on my machine™ (actually semi-field-tested against a serial device from a Linux host and communications appear to work).
Reviews and eventual merge are welcome.

Closes #71 and #76 