### PR TITLE
Clean up and reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,17 @@ repository = "https://github.com/slowtec/tokio-modbus"
 edition = "2018"
 
 [dependencies]
-bytes = "1"
 byteorder = "1"
+bytes = "1"
 futures = { version = "0.3", optional = true }
 futures-util = { version = "0.3", default-features = false }
 log = "0.4"
-socket2 = { version = "0.4", optional = true, features = ["all"]}
 smallvec = { version = "1", default-features = false }
-tokio-util = { version = "0.6", features = ["codec"] }
+socket2 = { version = "0.4", optional = true, features = ["all"]}
 tokio = { version = "1", default-features = false }
 # Disable default-features to exclude unused dependency on libudev
 tokio-serial = { version = "5.4.0-beta4", optional = true, default-features = false }
+tokio-util = { version = "0.6", features = ["codec"] }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ smallvec = { version = "1", default-features = false }
 tokio-util = { version = "0.6", features = ["codec"] }
 tokio = { version = "1", default-features = false }
 # Disable default-features to exclude unused dependency on libudev
-tokio-serial = { version = "5.4.0-beta1", optional = true, default-features = false }
+tokio-serial = { version = "5.4.0-beta4", optional = true, default-features = false }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 byteorder = "1"
 bytes = "1"
 futures = { version = "0.3", optional = true }
-futures-util = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", optional = true, default-features = false }
 log = "0.4"
 smallvec = { version = "1", default-features = false }
 socket2 = { version = "0.4", optional = true, features = ["all"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures = { version = "0.3", optional = true }
 futures-util = { version = "0.3", optional = true, default-features = false }
 log = "0.4"
 smallvec = { version = "1", default-features = false }
-socket2 = { version = "0.4", optional = true, features = ["all"]}
+socket2 = { version = "0.4", optional = true, default-features = false }
 tokio = { version = "1", default-features = false }
 # Disable default-features to exclude unused dependency on libudev
 tokio-serial = { version = "5.4.0-beta4", optional = true, default-features = false }
@@ -33,7 +33,7 @@ default = ["tcp", "rtu", "sync"]
 rtu = ["tokio-serial", "futures-util/sink"]
 tcp = ["tokio/net", "futures-util/sink"]
 sync = []
-server = ["socket2", "futures", "tokio/rt", "tokio/rt-multi-thread"]
+server = ["futures", "socket2/all", "tokio/rt", "tokio/rt-multi-thread"]
 tcp-server-unstable = ["server"]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,23 +18,22 @@ futures-util = { version = "0.3", default-features = false }
 log = "0.4"
 socket2 = { version = "0.4", optional = true, features = ["all"]}
 smallvec = { version = "1", default-features = false }
-# rt should be enabled only with "server" feature. Waiting for https://github.com/rust-lang/cargo/issues/5954
-tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 tokio-util = { version = "0.6", features = ["codec"] }
+tokio = { version = "1", default-features = false }
 # Disable default-features to exclude unused dependency on libudev
 tokio-serial = { version = "5.4.0-beta1", optional = true, default-features = false }
 
 [dev-dependencies]
 env_logger = "0.9"
 futures = "0.3"
-tokio = { version = "1", features = ["net", "macros", "io-util"] }
+tokio = { version = "1", features = ["net", "macros", "io-util", "rt"] }
 
 [features]
 default = ["tcp", "rtu", "sync"]
 rtu = ["tokio-serial", "futures-util/sink"]
 tcp = ["tokio/net", "futures-util/sink"]
 sync = []
-server = ["socket2", "futures"]
+server = ["socket2", "futures", "tokio/rt", "tokio/rt-multi-thread"]
 tcp-server-unstable = ["server"]
 
 [badges]


### PR DESCRIPTION
It turns out that we can disable unneeded `tokio` features if the unstable server feature is not used.

Or did I miss something? I wonder why we didn't notice this opportunity before.