### PR TITLE
Clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,5 @@
-# Cargo artefacts
+# Cargo artifacts
 Cargo.lock
 
-# Build directory (or a symbolic link to it)
+# Build directory (without a trailing slash to allow using symbolic links)
 /target
-
-# Backup files
-**/*~
-**/*.rs.bk
-
-# macOS
-.DS_Store
-
-# vi files
-*.swp
-
-# VS Code config files
-/.vscode


### PR DESCRIPTION
Platform-dependent extensions or temporary files caused by custom tools
(like the used editor or IDE) do not belong into the project's .gitignore
file. Instead they must be added to the global .gitignore file which is
placed in the home directory or any other parent directory.