### PR TITLE
RTU server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,11 @@ path = "examples/rtu-client.rs"
 required-features = ["rtu"]
 
 [[example]]
+name = "rtu-server"
+path = "examples/rtu-server.rs"
+required-features = ["rtu", "server"]
+
+[[example]]
 name = "tcp-client-custom-fn"
 path = "examples/tcp-client-custom-fn.rs"
 required-features = ["tcp"]

--- a/examples/rtu-server.rs
+++ b/examples/rtu-server.rs
@@ -1,0 +1,47 @@
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use futures::future;
+    use std::{thread, time::Duration};
+
+    use tokio_modbus::prelude::*;
+    use tokio_modbus::server::{self, Service};
+
+    struct MbServer;
+
+    impl Service for MbServer {
+        type Request = Request;
+        type Response = Response;
+        type Error = std::io::Error;
+        type Future = future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn call(&self, req: Self::Request) -> Self::Future {
+            match req {
+                Request::ReadInputRegisters(_addr, cnt) => {
+                    let mut registers = vec![0; cnt as usize];
+                    registers[2] = 0x77;
+                    future::ready(Ok(Response::ReadInputRegisters(registers)))
+                }
+                _ => unimplemented!(),
+            }
+        }
+    }
+
+    let (client_serial, server_serial) = tokio_serial::SerialStream::pair().unwrap();
+    println!("Starting up server...");
+    let _server = thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let server = server::rtu::Server::new(server_serial);
+        rt.block_on(async {server.serve_forever(|| Ok(MbServer)).await;});
+    });
+
+    // Give the server some time for stating up
+    thread::sleep(Duration::from_secs(1));
+
+    println!("Connecting client...");
+    let mut ctx = rtu::connect(client_serial).await?;
+    println!("Reading input registers...");
+    let rsp = ctx.read_input_registers(0x00, 7).await?;
+    println!("The result is '{:#x?}'", rsp); // The result is '[0x0,0x0,0x77,0x0,0x0,0x0,0x0,]'
+
+    Ok(())
+}

--- a/examples/rtu-server.rs
+++ b/examples/rtu-server.rs
@@ -31,7 +31,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _server = thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let server = server::rtu::Server::new(server_serial);
-        rt.block_on(async {server.serve_forever(|| Ok(MbServer)).await;});
+        rt.block_on(async {
+            server.serve_forever(|| Ok(MbServer)).await;
+        });
     });
 
     // Give the server some time for stating up

--- a/examples/rtu-server.rs
+++ b/examples/rtu-server.rs
@@ -26,7 +26,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let (client_serial, server_serial) = tokio_serial::SerialStream::pair().unwrap();
+    let builder = tokio_serial::new("/dev/ttyUSB0", 19200);
+    let server_serial = tokio_serial::SerialStream::open(&builder).unwrap();
+
     println!("Starting up server...");
     let _server = thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().unwrap();
@@ -40,6 +42,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(Duration::from_secs(1));
 
     println!("Connecting client...");
+    let client_serial = tokio_serial::SerialStream::open(&builder).unwrap();
     let mut ctx = rtu::connect(client_serial).await?;
     println!("Reading input registers...");
     let rsp = ctx.read_input_registers(0x00, 7).await?;

--- a/examples/tcp-client-sync.rs
+++ b/examples/tcp-client-sync.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "tcp", feature = "sync"))]
 pub fn main() {
     use tokio_modbus::prelude::*;
 
@@ -6,10 +5,4 @@ pub fn main() {
     let mut ctx = sync::tcp::connect(socket_addr).unwrap();
     let buff = ctx.read_input_registers(0x1000, 7).unwrap();
     println!("Response is '{:?}'", buff);
-}
-
-#[cfg(not(all(feature = "tcp", feature = "sync")))]
-pub fn main() {
-    println!("features `tcp` and `sync` are required to run this example");
-    std::process::exit(1);
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "tcp-server-unstable")]
-pub mod tcp;
 #[cfg(feature = "rtu")]
 pub mod rtu;
+#[cfg(feature = "tcp-server-unstable")]
+pub mod tcp;
 
 mod service;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "tcp-server-unstable")]
 pub mod tcp;
+#[cfg(feature = "rtu")]
+pub mod rtu;
 
 mod service;
 

--- a/src/server/rtu.rs
+++ b/src/server/rtu.rs
@@ -1,0 +1,103 @@
+/*!
+ * Modbus RTU server functionality
+ */
+
+use crate::{
+    codec,
+    frame::*,
+    server::service::{NewService, Service},
+};
+use std::{
+    io::{Error},
+    path::Path
+};
+use tokio_util::codec::Framed;
+use futures::{select, Future, FutureExt};
+use futures_util::{StreamExt, SinkExt};
+use tokio_serial::{SerialStream};
+
+pub struct Server {
+    serial: SerialStream
+}
+
+impl Server {
+    /// set up a new Server instance from an interface path and baud rate
+    pub fn new_from_path<P: AsRef<Path>>(p: P, baud_rate: u32) -> Result<Self, Error> {
+        let serial = SerialStream::open(&tokio_serial::new(p.as_ref().to_string_lossy(), baud_rate))?;
+        Ok(Server {
+            serial
+        })
+    }
+
+    /// set up a new Server instance based on a pre-configured SerialStream instance
+    pub fn new(serial: SerialStream) -> Self {
+        Server {
+            serial
+        }
+    }
+
+    /// serve Modbus RTU requests based on the provided service until it finishes
+    pub async fn serve_forever<S>(self, new_service: S)
+        where
+            S: NewService<Request = Request, Response = Response> + Send + Sync + 'static,
+            S::Error: Into<Error>,
+            S::Instance: 'static + Send + Sync,
+    {
+        self.serve_until(new_service, futures::future::pending()).await;
+    }
+
+    /// serve Modbus RTU requests based on the provided service until it finishes or a shutdown signal is received
+    pub async fn serve_until<S, Sd>(self, new_service: S, shutdown_signal: Sd)
+    where
+        S: NewService<Request = Request, Response = Response> + Send + Sync + 'static,
+        Sd: Future<Output = ()> + Sync + Send + Unpin + 'static,
+        S::Request: From<Request>,
+        S::Response: Into<Response>,
+        S::Error: Into<Error>,
+        S::Instance: Send + Sync + 'static,
+    {
+        let framed = Framed::new(self.serial, codec::rtu::ServerCodec::default());
+        let service = new_service.new_service().unwrap();
+        let future = process(framed, service);
+
+        let mut server = Box::pin(future).fuse();
+        let mut shutdown = shutdown_signal.fuse();
+
+        async {
+            select!{
+                res = server => if let Err(e) = res {
+                    println!("error: {}", e);
+                },
+                _ = shutdown => println!("Shutdown signal received")
+            }
+        }.await;
+    }
+}
+
+/// frame wrapper around the underlying service's responses to forwarded requests
+async fn process<S>(
+    mut framed: Framed<SerialStream, codec::rtu::ServerCodec>,
+    service: S,
+) -> Result<(), Error>
+    where
+        S: Service<Request = Request, Response = Response> + Send + Sync + 'static,
+        S::Error: Into<Error>,
+{
+    loop {
+        let request = match framed.next().await {
+            // Stream is exhausted
+            None => break,
+            Some(request) => request,
+        }?;
+
+        let hdr = request.hdr;
+        let response = service.call(request.pdu.0).await.map_err(Into::into)?;
+        framed.send(
+            rtu::ResponseAdu {
+                hdr,
+                pdu: response.into(),
+            }
+        ).await?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Adds RTU server functionality based on #72

This PR simply replicates that previous proposal that was sidelined by the #78 merge, but updated to compile based on the changes in `tokio-serial`.

Functionality has absolutely not been field-tested by me (beyond the provided example code), and since I have no practical use-case for an RTU server application, I'd ask someone more involved in this field (like @efancier-cn @ivomurrell or @david-mcgillicuddy-moixa) to do the necessary validations.

Closes #73 