### PR TITLE
Use `async_trait`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/slowtec/tokio-modbus"
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1"
 byteorder = "1"
 bytes = "1"
 futures = { version = "0.3", optional = true }

--- a/examples/rtu-client-shared-context.rs
+++ b/examples/rtu-client-shared-context.rs
@@ -1,6 +1,6 @@
 #[tokio::main(flavor = "current_thread")]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use std::{cell::RefCell, future::Future, io::Error, pin::Pin, rc::Rc};
+    use std::{cell::RefCell, io::Error, rc::Rc};
 
     use tokio_modbus::client::{
         rtu,
@@ -18,13 +18,12 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         builder: SerialPortBuilder,
     }
 
+    #[async_trait::async_trait]
     impl NewContext for SerialConfig {
-        fn new_context(&self) -> Pin<Box<dyn Future<Output = Result<Context, Error>>>> {
+        async fn new_context(&self) -> Result<Context, Error> {
             let serial = SerialStream::open(&self.builder);
-            Box::pin(async {
-                let port = serial?;
-                rtu::connect(port).await
-            })
+            let port = serial?;
+            rtu::connect(port).await
         }
     }
 

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -206,7 +206,7 @@ fn calc_crc(data: &[u8]) -> u16 {
 }
 
 fn check_crc(adu_data: &[u8], expected_crc: u16) -> Result<()> {
-    let actual_crc = calc_crc(&adu_data);
+    let actual_crc = calc_crc(adu_data);
     if expected_crc != actual_crc {
         return Err(Error::new(
             ErrorKind::InvalidData,

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -9,7 +9,6 @@ use futures_util::{future, sink::SinkExt, stream::StreamExt};
 use std::{
     future::Future,
     io::{Error, ErrorKind},
-    pin::Pin,
 };
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
@@ -89,12 +88,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin + 'static> SlaveContext for Context<T> {
     }
 }
 
+#[async_trait::async_trait]
 impl<T: AsyncRead + AsyncWrite + Unpin + Send + 'static> Client for Context<T> {
-    fn call<'a>(
-        &'a mut self,
-        req: Request,
-    ) -> Pin<Box<dyn Future<Output = Result<Response, Error>> + Send + 'a>> {
-        Box::pin(self.call(req))
+    async fn call<'a>(&'a mut self, req: Request) -> Result<Response, Error> {
+        self.call(req).await
     }
 }
 

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -10,7 +10,6 @@ use std::{
     future::Future,
     io::{Error, ErrorKind},
     net::SocketAddr,
-    pin::Pin,
     sync::atomic::{AtomicU16, Ordering},
 };
 use tokio::net::TcpStream;
@@ -114,11 +113,9 @@ impl SlaveContext for Context {
     }
 }
 
+#[async_trait::async_trait]
 impl Client for Context {
-    fn call<'a>(
-        &'a mut self,
-        req: Request,
-    ) -> Pin<Box<dyn Future<Output = Result<Response, Error>> + Send + 'a>> {
-        Box::pin(Context::call(self, req))
+    async fn call<'a>(&'a mut self, req: Request) -> Result<Response, Error> {
+        Context::call(self, req).await
     }
 }


### PR DESCRIPTION
First-pass implementation that applies `async_trait` syntax to the `Client`, `Reader` and `Writer` traits in `client/mod.rs` as well as to the `NewContext` trait in `client/util.rs`.

Note that this leaves the explicit `Future` generics from the `Service` trait in `server/service.rs` untouched and also doesn't introduce `async` syntax on functions like `connect[_slave]` in `client/tcp.rs`, `service/tcp.rs` and `service/rtu.rs`. I can still try to work out something there if desired.

Closes #82