### PR TITLE
Update to final tokio-serial 5.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ smallvec = { version = "1", default-features = false }
 socket2 = { version = "0.4", optional = true, default-features = false }
 tokio = { version = "1", default-features = false }
 # Disable default-features to exclude unused dependency on libudev
-tokio-serial = { version = "5.4.0-beta4", optional = true, default-features = false }
+tokio-serial = { version = "5.4.1", optional = true, default-features = false }
 tokio-util = { version = "0.6", features = ["codec"] }
 
 [dev-dependencies]


### PR DESCRIPTION
The final version of tokio serial 5.x is out now. No functional changes since 5.4.0-beta4.
This PR brings us one step closer towards #80 