### PR TITLE
Fix multiplication overflow for function 1 and 2

### DIFF
--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -234,7 +234,7 @@ impl TryFrom<Bytes> for Response {
                 let x = &bytes[2..];
                 // Here we have not information about the exact requested quantity so we just
                 // unpack the whole byte.
-                let quantity = byte_count as u16 * 8;
+                let quantity = u16::from(byte_count) * 8;
                 ReadCoils(unpack_coils(x, quantity))
             }
             0x02 => {
@@ -242,7 +242,7 @@ impl TryFrom<Bytes> for Response {
                 let x = &bytes[2..];
                 // Here we have no information about the exact requested quantity so we just
                 // unpack the whole byte.
-                let quantity = byte_count as u16 * 8;
+                let quantity = u16::from(byte_count) * 8;
                 ReadDiscreteInputs(unpack_coils(x, quantity))
             }
             0x05 => WriteSingleCoil(

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -234,7 +234,7 @@ impl TryFrom<Bytes> for Response {
                 let x = &bytes[2..];
                 // Here we have not information about the exact requested quantity so we just
                 // unpack the whole byte.
-                let quantity = u16::from(byte_count * 8);
+                let quantity = byte_count as u16 * 8;
                 ReadCoils(unpack_coils(x, quantity))
             }
             0x02 => {
@@ -242,7 +242,7 @@ impl TryFrom<Bytes> for Response {
                 let x = &bytes[2..];
                 // Here we have no information about the exact requested quantity so we just
                 // unpack the whole byte.
-                let quantity = u16::from(byte_count * 8);
+                let quantity = byte_count as u16 * 8;
                 ReadDiscreteInputs(unpack_coils(x, quantity))
             }
             0x05 => WriteSingleCoil(

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -970,6 +970,21 @@ mod tests {
         }
 
         #[test]
+        fn read_coils_max_quantity() {
+            let quantity = 2000;
+            let byte_count = quantity / 8;
+            let mut raw : Vec<u8> = vec![1, byte_count as u8];
+            let mut values : Vec<u8> = (0..byte_count).map(|_| 0b_1111_1111).collect();
+            raw.append(&mut values);
+            let bytes = Bytes::from(raw);
+            let rsp = Response::try_from(bytes).unwrap();
+            assert_eq!(
+                rsp,
+                Response::ReadCoils(vec![true; quantity])
+            );
+        }
+
+        #[test]
         fn read_discrete_inputs() {
             let bytes = Bytes::from(vec![2, 1, 0b_0000_1001]);
             let rsp = Response::try_from(bytes).unwrap();
@@ -978,6 +993,21 @@ mod tests {
                 Response::ReadDiscreteInputs(vec![
                     true, false, false, true, false, false, false, false,
                 ],)
+            );
+        }
+
+        #[test]
+        fn read_discrete_inputs_max_quantity() {
+            let quantity = 2000;
+            let byte_count = quantity / 8;
+            let mut raw : Vec<u8> = vec![2, byte_count as u8];
+            let mut values : Vec<u8> = (0..byte_count).map(|_| 0b_1111_1111).collect();
+            raw.append(&mut values);
+            let bytes = Bytes::from(raw);
+            let rsp = Response::try_from(bytes).unwrap();
+            assert_eq!(
+                rsp,
+                Response::ReadDiscreteInputs(vec![true; quantity])
             );
         }
 


### PR DESCRIPTION
The original code calculated required buffer space for decoded values by
mutiplying `byte_count` by 8. Since `byte_count` was given the type
`u8`, the multiplication result would overflowed if `byte_count` is
greater than 31. In other words, if more than 248 coils/discrete inputs
were requested.

This PR cast `byte_count` to u16 before it is used to calculate the
required buffer space, thus prevents the overflow.