### PR TITLE
Remove `sync` from default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.5.0 (Unreleased)
 
+- Removed `sync` from default features
 - Upgraded [tokio](https://tokio.rs/) version from 0.2 to 1
 - Switched from deprecated [net2](https://github.com/deprecrated/net2-rs) to [socket2](https://github.com/rust-lang/socket2)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3"
 tokio = { version = "1", features = ["net", "macros", "io-util", "rt"] }
 
 [features]
-default = ["tcp", "rtu", "sync"]
+default = ["tcp", "rtu"]
 rtu = ["tokio-serial", "futures-util/sink"]
 tcp = ["tokio/net", "futures-util/sink"]
 sync = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ homepage = "https://github.com/slowtec/tokio-modbus"
 repository = "https://github.com/slowtec/tokio-modbus"
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 async-trait = "0.1"
 byteorder = "1"

--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ A [tokio](https://tokio.rs)-based modbus library.
 
 ## Features
 
-- pure Rust library
-- async (non-blocking)
-- sync (blocking)
-- Modbus TCP
-- Modbus RTU
-- Client & Server
-- Open Source (MIT/Apache-2.0)
+- Pure Rust library
+- Modbus TCP or RTU at your choice
+- Both `async` (non-blocking, default) and `sync` (blocking, optional)
+- Client API
+- Server implementations
+  - for *out-of-the-box* usage or
+  - as a starting point for a customized implementation
+- Open source (MIT/Apache-2.0)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ or synchronous API can be found in the
 [examples](https://github.com/slowtec/tokio-modbus/tree/master/examples)
 folder.
 
+## Testing
+
+The workspace contains documentation, tests, and examples for all available
+features. Running the tests for the whole workspace only succeeds with all
+features enabled:
+
+```sh
+cargo test --workspace --all-features
+```
+
+Otherwise some *doctests* that require non-default features like `sync`
+are expected to fail.
+
 ## Protocol-Specification
 
 - [MODBUS Application Protocol Specification v1.1b3 (PDF)](http://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf)


### PR DESCRIPTION
Please see the README for a yet unresolved side-effect. I didn't find a workaround for this limitation.