### PR TITLE
Improve error messages for failing `sync` doc tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(all(feature = "tcp", feature = "sync"))]
+//! # //FIXME: Run doc tests with `--features sync` to fix failure
 //! pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     use tokio_modbus::prelude::*;
 //!
@@ -114,6 +115,7 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(all(feature = "rtu", feature = "sync"))]
+//! # //FIXME: Run doc tests with `--features sync` to fix failure
 //! pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     use tokio_modbus::prelude::*;
 //!


### PR DESCRIPTION
Not sophisticated, but effective ;) Run tests with `cargo test --workspace` and watch the output.