### PR TITLE
Lifetime cleanup on `async_trait` usage

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -19,34 +19,23 @@ use async_trait::async_trait;
 /// A transport independent asynchronous client trait.
 #[async_trait]
 pub trait Client: SlaveContext + Send + Debug {
-    async fn call<'a>(&'a mut self, request: Request) -> Result<Response, Error>;
+    async fn call(&mut self, request: Request) -> Result<Response, Error>;
 }
 
 /// An asynchronous Modbus reader.
 #[async_trait]
 pub trait Reader: Client {
-    async fn read_coils<'a>(&'a mut self, _: Address, _: Quantity) -> Result<Vec<Coil>, Error>;
+    async fn read_coils(&mut self, _: Address, _: Quantity) -> Result<Vec<Coil>, Error>;
 
-    async fn read_discrete_inputs<'a>(
-        &'a mut self,
-        _: Address,
-        _: Quantity,
-    ) -> Result<Vec<Coil>, Error>;
+    async fn read_discrete_inputs(&mut self, _: Address, _: Quantity) -> Result<Vec<Coil>, Error>;
 
-    async fn read_input_registers<'a>(
-        &'a mut self,
-        _: Address,
-        _: Quantity,
-    ) -> Result<Vec<Word>, Error>;
+    async fn read_input_registers(&mut self, _: Address, _: Quantity) -> Result<Vec<Word>, Error>;
 
-    async fn read_holding_registers<'a>(
-        &'a mut self,
-        _: Address,
-        _: Quantity,
-    ) -> Result<Vec<Word>, Error>;
+    async fn read_holding_registers(&mut self, _: Address, _: Quantity)
+        -> Result<Vec<Word>, Error>;
 
-    async fn read_write_multiple_registers<'a>(
-        &'a mut self,
+    async fn read_write_multiple_registers(
+        &mut self,
         _: Address,
         _: Quantity,
         _: Address,
@@ -57,17 +46,13 @@ pub trait Reader: Client {
 /// An asynchronous Modbus writer.
 #[async_trait]
 pub trait Writer: Client {
-    async fn write_single_coil<'a>(&'a mut self, _: Address, _: Coil) -> Result<(), Error>;
+    async fn write_single_coil(&mut self, _: Address, _: Coil) -> Result<(), Error>;
 
-    async fn write_multiple_coils<'a>(&'a mut self, _: Address, _: &[Coil]) -> Result<(), Error>;
+    async fn write_multiple_coils(&mut self, _: Address, _: &[Coil]) -> Result<(), Error>;
 
-    async fn write_single_register<'a>(&'a mut self, _: Address, _: Word) -> Result<(), Error>;
+    async fn write_single_register(&mut self, _: Address, _: Word) -> Result<(), Error>;
 
-    async fn write_multiple_registers<'a>(
-        &'a mut self,
-        _: Address,
-        _: &[Word],
-    ) -> Result<(), Error>;
+    async fn write_multiple_registers(&mut self, _: Address, _: &[Word]) -> Result<(), Error>;
 }
 
 /// An asynchronous Modbus client context.

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -191,14 +191,10 @@ fn calc_crc(data: &[u8]) -> u16 {
     for x in data {
         crc ^= u16::from(*x);
         for _ in 0..8 {
-            // if we followed clippy's suggestion to move out the crc >>= 1, the condition may not be met any more
-            // the recommended action therefore makes no sense and it is better to allow this lint
-            #[allow(clippy::branches_sharing_code)]
-            if (crc & 0x0001) != 0 {
-                crc >>= 1;
+            let crc_odd = (crc & 0x0001) != 0;
+            crc >>= 1;
+            if crc_odd {
                 crc ^= 0xA001;
-            } else {
-                crc >>= 1;
             }
         }
     }

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -92,7 +92,7 @@ impl<T: AsyncRead + AsyncWrite + Debug + Unpin + 'static> SlaveContext for Conte
 
 #[async_trait::async_trait]
 impl<T: AsyncRead + AsyncWrite + Debug + Unpin + Send + 'static> Client for Context<T> {
-    async fn call<'a>(&'a mut self, req: Request) -> Result<Response, Error> {
+    async fn call(&mut self, req: Request) -> Result<Response, Error> {
         self.call(req).await
     }
 }

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -116,7 +116,7 @@ impl SlaveContext for Context {
 
 #[async_trait::async_trait]
 impl Client for Context {
-    async fn call<'a>(&'a mut self, req: Request) -> Result<Response, Error> {
+    async fn call(&mut self, req: Request) -> Result<Response, Error> {
         Context::call(self, req).await
     }
 }


### PR DESCRIPTION
* removed redundant explicit lifetimes in async_trait functions
* also changed CRC code so that clippy won't complain