### PR TITLE
Update methods on TCP server to be async to allow returning the future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio-util = { version = "0.6", features = ["codec"] }
 [dev-dependencies]
 env_logger = "0.9"
 futures = "0.3"
-tokio = { version = "1", features = ["net", "macros", "io-util", "rt"] }
+tokio = { version = "1", features = ["net", "macros", "io-util", "rt", "time"] }
 
 [features]
 default = ["tcp", "rtu"]

--- a/examples/tcp-server.rs
+++ b/examples/tcp-server.rs
@@ -1,45 +1,59 @@
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    use futures::future;
-    use std::{thread, time::Duration};
+use futures::future;
+use std::{net::SocketAddr, time::Duration};
 
-    use tokio_modbus::prelude::*;
-    use tokio_modbus::server::{self, Service};
+use tokio_modbus::prelude::*;
+use tokio_modbus::server::{self, Service};
 
-    struct MbServer;
+struct MbServer;
 
-    impl Service for MbServer {
-        type Request = Request;
-        type Response = Response;
-        type Error = std::io::Error;
-        type Future = future::Ready<Result<Self::Response, Self::Error>>;
+impl Service for MbServer {
+    type Request = Request;
+    type Response = Response;
+    type Error = std::io::Error;
+    type Future = future::Ready<Result<Self::Response, Self::Error>>;
 
-        fn call(&self, req: Self::Request) -> Self::Future {
-            match req {
-                Request::ReadInputRegisters(_addr, cnt) => {
-                    let mut registers = vec![0; cnt as usize];
-                    registers[2] = 0x77;
-                    future::ready(Ok(Response::ReadInputRegisters(registers)))
-                }
-                _ => unimplemented!(),
+    fn call(&self, req: Self::Request) -> Self::Future {
+        match req {
+            Request::ReadInputRegisters(_addr, cnt) => {
+                let mut registers = vec![0; cnt as usize];
+                registers[2] = 77;
+                future::ready(Ok(Response::ReadInputRegisters(registers)))
             }
+            _ => unimplemented!(),
         }
     }
+}
 
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let socket_addr = "127.0.0.1:5502".parse().unwrap();
 
-    println!("Starting up server...");
-    let _server = thread::spawn(move || {
-        server::tcp::Server::new(socket_addr).serve(|| Ok(MbServer));
-    });
-    // Give the server some time for stating up
-    thread::sleep(Duration::from_secs(1));
-
-    println!("Connecting client...");
-    let mut ctx = tcp::connect(socket_addr).await?;
-    println!("Reading input registers...");
-    let rsp = ctx.read_input_registers(0x00, 7).await?;
-    println!("The result is '{:?}'", rsp);
+    tokio::select! {
+        _ = server_context(socket_addr) => unreachable!(),
+        _ = client_context(socket_addr) => println!("Exiting"),
+    }
 
     Ok(())
+}
+
+async fn server_context(socket_addr: SocketAddr) {
+    println!("Starting up server...");
+    let server = server::tcp::Server::new(socket_addr);
+    server.serve(|| Ok(MbServer)).await.unwrap();
+}
+
+async fn client_context(socket_addr: SocketAddr) {
+    tokio::join!(
+        async {
+            // Give the server some time for starting up
+            tokio::time::sleep(Duration::from_secs(1)).await;
+
+            println!("Connecting client...");
+            let mut ctx = tcp::connect(socket_addr).await.unwrap();
+            println!("Reading input registers...");
+            let response = ctx.read_input_registers(0x00, 7).await.unwrap();
+            println!("The result is '{:?}'", response);
+        },
+        tokio::time::sleep(Duration::from_secs(5))
+    );
 }

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -24,9 +24,7 @@ pub struct Server {
 impl Server {
     /// Set the address for the server (mandatory).
     pub fn new(socket_addr: SocketAddr) -> Self {
-        Self {
-            socket_addr,
-        }
+        Self { socket_addr }
     }
 
     /// Start an async Modbus TCP server task.
@@ -125,6 +123,7 @@ where
 }
 
 /// Start TCP listener - configure and open TCP socket
+#[allow(unused)]
 fn listener(addr: SocketAddr, workers: usize) -> io::Result<TcpListener> {
     let listener = match addr {
         SocketAddr::V4(_) => Socket::new(Domain::IPV4, Type::STREAM, None)?,
@@ -138,6 +137,7 @@ fn listener(addr: SocketAddr, workers: usize) -> io::Result<TcpListener> {
 }
 
 #[cfg(unix)]
+#[allow(unused)]
 fn configure_tcp(workers: usize, tcp: &Socket) -> io::Result<()> {
     if workers > 1 {
         tcp.reuse_port()?;
@@ -146,6 +146,7 @@ fn configure_tcp(workers: usize, tcp: &Socket) -> io::Result<()> {
 }
 
 #[cfg(windows)]
+#[allow(unused)]
 fn configure_tcp(_workers: usize, _tcp: &Socket) -> io::Result<()> {
     Ok(())
 }


### PR DESCRIPTION
I'm using this crate for a project where we're primarily using the client side APIs, but have recently been working on making "mocked" devices for testing purposes. One difficulty I had was with standing up multiple Modbus servers in a single process since the API calls were internally building their own runtime (this causes a panic if you're already in an async context).

I've revamped the `server::tcp::Server` methods in order for `serve` to be async and for `serve_forever` to call into `serve` for the original use case of a `serve` call that blocks the current thread indefinitely.

One thing I noticed was that the calls related to the `socket2::Socket` seemed to be incompatible in some way with the preconditions expected by `mio`. I stopped using the `configure_tcp` and `listener` calls after discovering that the process was getting blocked on the `accept4` syscall on Linux. It wasn't clear what the intended purpose of those methods were as they seem redundant with setup that `mio` already does or it didn't seem to have an effect when I removed them. I'm happy to revisit though if there's something subtle that's been removed.