### PR TITLE
fix an issue when parsing read multiple registers requests in RTU

### DIFF
--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -433,11 +433,11 @@ mod tests {
         assert_eq!(get_request_pdu_len(&buf).unwrap(), Some(1));
 
         buf[1] = 0x0F;
-        buf[4] = 99;
+        buf[6] = 99;
         assert_eq!(get_request_pdu_len(&buf).unwrap(), Some(105));
 
         buf[1] = 0x10;
-        buf[4] = 99;
+        buf[6] = 99;
         assert_eq!(get_request_pdu_len(&buf).unwrap(), Some(105));
 
         buf[1] = 0x11;

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -123,8 +123,8 @@ fn get_request_pdu_len(adu_buf: &BytesMut) -> Result<Option<usize>> {
         0x01..=0x06 => Some(5),
         0x07 | 0x0B | 0x0C | 0x11 => Some(1),
         0x0F | 0x10 => {
-            if adu_buf.len() > 4 {
-                Some(6 + adu_buf[4] as usize)
+            if adu_buf.len() > 6 {
+                Some(6 + adu_buf[6] as usize)
             } else {
                 // incomplete frame
                 None


### PR DESCRIPTION
the byte count value resides in the 7th byte of the adu buf, instead of the 5th. this commit fixes it