### PR TITLE
Replace casts between primitive types with safe type conversions

### DIFF
--- a/examples/rtu-server.rs
+++ b/examples/rtu-server.rs
@@ -17,7 +17,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         fn call(&self, req: Self::Request) -> Self::Future {
             match req {
                 Request::ReadInputRegisters(_addr, cnt) => {
-                    let mut registers = vec![0; cnt as usize];
+                    let mut registers = vec![0; cnt.into()];
                     registers[2] = 0x77;
                     future::ready(Ok(Response::ReadInputRegisters(registers)))
                 }

--- a/examples/tcp-server.rs
+++ b/examples/tcp-server.rs
@@ -15,7 +15,7 @@ impl Service for MbServer {
     fn call(&self, req: Self::Request) -> Self::Future {
         match req {
             Request::ReadInputRegisters(_addr, cnt) => {
-                let mut registers = vec![0; cnt as usize];
+                let mut registers = vec![0; cnt.into()];
                 registers[2] = 77;
                 future::ready(Ok(Response::ReadInputRegisters(registers)))
             }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -110,8 +110,8 @@ impl Reader for Context {
         let rsp = self.client.call(Request::ReadCoils(addr, cnt)).await?;
 
         if let Response::ReadCoils(mut coils) = rsp {
-            debug_assert!(coils.len() >= cnt as usize);
-            coils.truncate(cnt as usize);
+            debug_assert!(coils.len() >= cnt.into());
+            coils.truncate(cnt.into());
             Ok(coils)
         } else {
             Err(Error::new(ErrorKind::InvalidData, "unexpected response"))
@@ -129,8 +129,8 @@ impl Reader for Context {
             .await?;
 
         if let Response::ReadDiscreteInputs(mut coils) = rsp {
-            debug_assert!(coils.len() >= cnt as usize);
-            coils.truncate(cnt as usize);
+            debug_assert!(coils.len() >= cnt.into());
+            coils.truncate(cnt.into());
             Ok(coils)
         } else {
             Err(Error::new(ErrorKind::InvalidData, "unexpected response"))
@@ -148,7 +148,7 @@ impl Reader for Context {
             .await?;
 
         if let Response::ReadInputRegisters(rsp) = rsp {
-            if rsp.len() != cnt as usize {
+            if rsp.len() != cnt.into() {
                 return Err(Error::new(ErrorKind::InvalidData, "invalid response"));
             }
             Ok(rsp)
@@ -168,7 +168,7 @@ impl Reader for Context {
             .await?;
 
         if let Response::ReadHoldingRegisters(rsp) = rsp {
-            if rsp.len() != cnt as usize {
+            if rsp.len() != cnt.into() {
                 return Err(Error::new(ErrorKind::InvalidData, "invalid response"));
             }
             Ok(rsp)
@@ -195,7 +195,7 @@ impl Reader for Context {
             .await?;
 
         if let Response::ReadWriteMultipleRegisters(rsp) = rsp {
-            if rsp.len() != read_cnt as usize {
+            if rsp.len() != read_cnt.into() {
                 return Err(Error::new(ErrorKind::InvalidData, "invalid response"));
             }
             Ok(rsp)
@@ -235,7 +235,7 @@ impl Writer for Context {
             .await?;
 
         if let Response::WriteMultipleCoils(rsp_addr, rsp_cnt) = rsp {
-            if rsp_addr != addr || rsp_cnt as usize != cnt {
+            if rsp_addr != addr || usize::from(rsp_cnt) != cnt {
                 return Err(Error::new(ErrorKind::InvalidData, "invalid response"));
             }
             Ok(())
@@ -276,7 +276,7 @@ impl Writer for Context {
             .await?;
 
         if let Response::WriteMultipleRegisters(rsp_addr, rsp_cnt) = rsp {
-            if rsp_addr != addr || rsp_cnt as usize != cnt {
+            if rsp_addr != addr || usize::from(rsp_cnt) != cnt {
                 return Err(Error::new(ErrorKind::InvalidData, "invalid response"));
             }
             Ok(())

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -12,6 +12,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use std::convert::TryFrom;
 use std::io::{self, Cursor, Error, ErrorKind};
 
+#[allow(clippy::cast_possible_truncation)]
 fn u16_len(len: usize) -> u16 {
     // This type conversion should always be safe, because either
     // the caller is responsible to pass a valid usize or the
@@ -20,6 +21,7 @@ fn u16_len(len: usize) -> u16 {
     len as u16
 }
 
+#[allow(clippy::cast_possible_truncation)]
 fn u8_len(len: usize) -> u8 {
     // This type conversion should always be safe, because either
     // the caller is responsible to pass a valid usize or the

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -120,12 +120,16 @@ fn get_request_pdu_len(adu_buf: &BytesMut) -> Result<Option<usize>> {
             0x01..=0x06 => 5,
             0x07 | 0x0B | 0x0C | 0x11 => 1,
             0x0F | 0x10 => {
-                return Ok(adu_buf.get(6).map(|&byte_count| 6 + byte_count as usize));
+                return Ok(adu_buf
+                    .get(6)
+                    .map(|&byte_count| 6 + usize::from(byte_count)));
             }
             0x16 => 7,
             0x18 => 3,
             0x17 => {
-                return Ok(adu_buf.get(10).map(|&byte_count| 10 + byte_count as usize));
+                return Ok(adu_buf
+                    .get(10)
+                    .map(|&byte_count| 10 + usize::from(byte_count)));
             }
             _ => {
                 return Err(Error::new(
@@ -144,14 +148,16 @@ fn get_response_pdu_len(adu_buf: &BytesMut) -> Result<Option<usize>> {
     if let Some(fn_code) = adu_buf.get(1) {
         let len = match fn_code {
             0x01..=0x04 | 0x0C | 0x17 => {
-                return Ok(adu_buf.get(2).map(|&byte_count| 2 + byte_count as usize));
+                return Ok(adu_buf
+                    .get(2)
+                    .map(|&byte_count| 2 + usize::from(byte_count)));
             }
             0x05 | 0x06 | 0x0B | 0x0F | 0x10 => 5,
             0x07 => 2,
             0x16 => 7,
             0x18 => {
                 if adu_buf.len() > 3 {
-                    3 + Cursor::new(&adu_buf[2..=3]).read_u16::<BigEndian>()? as usize
+                    3 + usize::from(Cursor::new(&adu_buf[2..=3]).read_u16::<BigEndian>()?)
                 } else {
                     // incomplete frame
                     return Ok(None);

--- a/src/codec/tcp.rs
+++ b/src/codec/tcp.rs
@@ -51,7 +51,7 @@ impl Decoder for AduDecoder {
         }
 
         debug_assert!(HEADER_LEN >= 6);
-        let len = BigEndian::read_u16(&buf[4..6]) as usize;
+        let len = usize::from(BigEndian::read_u16(&buf[4..6]));
         let pdu_len = if len > 0 {
             // len = bytes of PDU + one byte (unit ID)
             len - 1
@@ -146,7 +146,7 @@ impl Encoder<RequestAdu> for ClientCodec {
         buf.reserve(pdu_data.len() + 7);
         buf.put_u16(hdr.transaction_id);
         buf.put_u16(PROTOCOL_ID);
-        buf.put_u16((pdu_data.len() + 1) as u16);
+        buf.put_u16(u16_len(pdu_data.len() + 1));
         buf.put_u8(hdr.unit_id);
         buf.put_slice(&*pdu_data);
         Ok(())
@@ -162,7 +162,7 @@ impl Encoder<ResponseAdu> for ServerCodec {
         buf.reserve(pdu_data.len() + 7);
         buf.put_u16(hdr.transaction_id);
         buf.put_u16(PROTOCOL_ID);
-        buf.put_u16((pdu_data.len() + 1) as u16);
+        buf.put_u16(u16_len(pdu_data.len() + 1));
         buf.put_u8(hdr.unit_id);
         buf.put_slice(&*pdu_data);
         Ok(())

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -154,6 +154,7 @@ pub enum Response {
 
 /// A server (slave) exception.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum Exception {
     IllegalFunction = 0x01,
     IllegalDataAddress = 0x02,
@@ -164,6 +165,12 @@ pub enum Exception {
     MemoryParityError = 0x08,
     GatewayPathUnavailable = 0x0A,
     GatewayTargetDevice = 0x0B,
+}
+
+impl From<Exception> for u8 {
+    fn from(from: Exception) -> Self {
+        from as u8
+    }
 }
 
 impl Exception {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@
 //#![deny(clippy::must_use_candidate)]
 #![cfg_attr(not(test), warn(unsafe_code))]
 #![cfg_attr(not(test), deny(clippy::panic_in_result_fn))]
+#![cfg_attr(not(test), deny(clippy::cast_possible_truncation))]
 #![cfg_attr(not(debug_assertions), deny(warnings))]
 #![cfg_attr(not(debug_assertions), deny(clippy::used_underscore_binding))]
 


### PR DESCRIPTION
Casts would silently drop the least significant bits when applied incorrectly whereas explicit type conversions are checked by the compiler. Type conversions are only permitted when no information is lost.