### PR TITLE
Fix/tcp delay causing composite tcp packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 # Changelog
 
+## v0.5.4 (2022-11-15)
+
+- Fix TCP Server: Added nodelay to socket to prevent gathering of multiple Modbus ADUs into a single TCP PDU
+
 ## v0.5.3 (2022-06-22)
 
 - Fix (RTU/sync): Execute SerialStream::open within an async runtime [#116](https://github.com/slowtec/tokio-modbus/pull/116)

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -43,7 +43,6 @@ impl Server {
         S::Instance: Send + Sync + 'static,
     {
         let service = Arc::new(service);
-
         let socket = Socket::new(Domain::IPV4, Type::STREAM, None)?;
         socket.reuse_address()?;
         socket.set_nodelay(true)?;
@@ -121,7 +120,6 @@ where
         }
 
         let request = request.unwrap()?;
-
         let hdr = request.hdr;
         let response = service.call(request.pdu.0).await.map_err(Into::into)?;
 

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -21,6 +21,9 @@ use std::{
 use tokio::net::{TcpListener, TcpStream};
 use tokio_util::codec::Framed;
 
+/// The maximum number of connections queue for acception 
+const CONNECTION_QUEUE_MAX: i32 = 10;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Server {
     socket_addr: SocketAddr,
@@ -46,7 +49,7 @@ impl Server {
         let socket = Socket::new(Domain::IPV4, Type::STREAM, None)?;
         socket.set_nodelay(true)?;
         socket.bind(&self.socket_addr.into())?;
-        socket.listen(1024)?;
+        socket.listen(CONNECTION_QUEUE_MAX)?;
         let listener = TcpListener::from_std(socket.into())?;
 
         loop {

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -21,8 +21,8 @@ use std::{
 use tokio::net::{TcpListener, TcpStream};
 use tokio_util::codec::Framed;
 
-/// The maximum number of connections queue for acception 
-const CONNECTION_QUEUE_MAX: i32 = 10;
+/// Maximum number of pending connections that could be accepted 
+const SOCKET_LISTEN_BACKLOG: i32 = 10;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Server {
@@ -49,7 +49,7 @@ impl Server {
         let socket = Socket::new(Domain::IPV4, Type::STREAM, None)?;
         socket.set_nodelay(true)?;
         socket.bind(&self.socket_addr.into())?;
-        socket.listen(CONNECTION_QUEUE_MAX)?;
+        socket.listen(SOCKET_LISTEN_BACKLOG)?;
         let listener = TcpListener::from_std(socket.into())?;
 
         loop {

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -47,7 +47,7 @@ impl Server {
         socket.set_nodelay(true)?;
         socket.bind(&self.socket_addr.into())?;
         socket.listen(1024)?;
-        let listener =  TcpListener::from_std(socket.into())?;
+        let listener = TcpListener::from_std(socket.into())?;
 
         loop {
             let (stream, _) = listener.accept().await?;

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -44,7 +44,6 @@ impl Server {
     {
         let service = Arc::new(service);
         let socket = Socket::new(Domain::IPV4, Type::STREAM, None)?;
-        socket.reuse_address()?;
         socket.set_nodelay(true)?;
         socket.bind(&self.socket_addr.into())?;
         socket.listen(1024)?;


### PR DESCRIPTION
I was investigating a problem and noticed that we could trigger the modbus lib to 'collect' multiple Modbus ADUs into a single TCP PDU. 

This is from Wireshark showing the trace between the client (a nodejs script for testing purposes) and the server (baked with tokio-modbus): 
![image](https://user-images.githubusercontent.com/12253631/201349992-3564eb50-fb2d-451a-bd56-26fb8f9a56f9.png)

Notice that packet 113 has multiple responses, which can be viewed:
![image](https://user-images.githubusercontent.com/12253631/201350254-3feaac8b-70cb-44b8-aaa4-a3c03473b241.png)

I am pretty sure that this behavior is causing a problem for one of our customers, who is using a PLC which does support a list of Modbus ADUs in a single TCP PDU. In the other cases our customers PLCs must be waiting for the reponse before making a new request. 

From the [Modbus_Messaging_Implementation_Guide_V1_0b.pdf](http://modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf) in your README, it seems that this should not be done at all. 
At page 10:
![image](https://user-images.githubusercontent.com/12253631/201351736-41db465c-3c0b-4b04-ae29-9b95fd34dc6c.png)

This fix is simply to disable Nagle's algorithm by setting nodelay = true. This can not be done the tokio::net::TcpListener directly so I was forced to use from_std and constructing a standard socket.

I was considering making the nodelay a setting, but as it advised not to use it in the document above, I think it should be standard.

This is what it looks like after the fix.
Note that packet 102 / Transaction 5 has 3 requests (Modbus ADUs) in it. The Decoder is perfectly cable of handling this response .
![image](https://user-images.githubusercontent.com/12253631/201348813-d85c0f00-7779-457f-8bbf-8aa630c6abd1.png)
