### PR TITLE
sync: Fix panic when using client-side timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## v0.7.1 (2023-02-28)
 
 - Fix (sync): Panic when using client-side timeouts [#155](https://github.com/slowtec/tokio-modbus/issues/155)
+- tcp-server-unstable: Upgrade socket2 dependency
 
 ## v0.7.0 (2023-02-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 
 # Changelog
 
-## v0.7.0 (Unreleased)
+## v0.7.1 (2023-02-28)
+
+- Fix (sync): Panic when using client-side timeouts [#155](https://github.com/slowtec/tokio-modbus/issues/155)
+
+## v0.7.0 (2023-02-14)
 
 - Added: Optional timeout for synchronous RTU/TCP operations [#125](https://github.com/slowtec/tokio-modbus/issues/125).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "tokio-modbus"
 description = "Tokio-based Modbus library"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "slowtec GmbH <post@slowtec.de>",
     "Markus Kohlhase <markus.kohlhase@slowtec.de>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ futures = { version = "0.3.26", optional = true }
 futures-util = { version = "0.3.26", optional = true, default-features = false }
 log = "0.4.17"
 smallvec = { version = "1.10.0", default-features = false }
-socket2 = { version = "0.4.7", optional = true, default-features = false }
+socket2 = { version = "0.5.1", optional = true, default-features = false }
 tokio = { version = "1.25.0", default-features = false }
 # Disable default-features to exclude unused dependency on libudev
 tokio-serial = { version = "5.4.4", optional = true, default-features = false }

--- a/src/client/sync/rtu.rs
+++ b/src/client/sync/rtu.rs
@@ -38,6 +38,7 @@ pub fn connect_slave_with_timeout(
 ) -> Result<Context> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_io()
+        .enable_time()
         .build()?;
     // SerialStream::open requires a runtime at least on cfg(unix).
     let serial = runtime.block_on(async { SerialStream::open(builder) })?;

--- a/src/client/sync/tcp.rs
+++ b/src/client/sync/tcp.rs
@@ -36,6 +36,7 @@ pub fn connect_slave_with_timeout(
 ) -> Result<Context> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_io()
+        .enable_time()
         .build()?;
     let async_ctx =
         block_on_with_timeout(&runtime, timeout, async_connect_slave(socket_addr, slave))?;


### PR DESCRIPTION
- v0.7.1
- Fixes #155 
- tcp-server-unstable: Upgrade socket2 dependency (marked as _unstable_, so this possibly breaking change doesn't matter)