### PR TITLE
docs: Make type aliases public to reveal documentation

### DIFF
--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod tcp;
 use std::{error, fmt};
 
 /// A Modbus function code is represented by an unsigned 8 bit integer.
-pub(crate) type FunctionCode = u8;
+pub type FunctionCode = u8;
 
 /// A Modbus protocol address is represented by 16 bit from `0` to `65535`.
 ///
@@ -18,7 +18,7 @@ pub(crate) type FunctionCode = u8;
 /// *register address* is often specified as a number with 1-based indexing.
 /// Please consult the specification of your devices if 1-based coil/register
 /// addresses need to be converted to 0-based protocol addresses by subtracting 1.
-pub(crate) type Address = u16;
+pub type Address = u16;
 
 /// A Coil represents a single bit.
 ///
@@ -26,11 +26,13 @@ pub(crate) type Address = u16;
 /// - `false` is equivalent to `OFF`, `0` and `0x0000`.
 pub(crate) type Coil = bool;
 
-/// Modbus uses 16 bit for its data items (big-endian representation).
+/// Modbus uses 16 bit for its data items.
+///
+/// Transmitted using a big-endian representation.
 pub(crate) type Word = u16;
 
-/// Number of items to process (`0` - `65535`).
-pub(crate) type Quantity = u16;
+/// Number of items to process.
+pub type Quantity = u16;
 
 /// A request represents a message from the client (master) to the server (slave).
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,14 @@ pub mod prelude;
 pub mod client;
 
 pub mod slave;
+pub use self::slave::{Slave, SlaveId};
+
+mod codec;
+
+mod frame;
+pub use self::frame::{Address, FunctionCode, Quantity, Request, Response};
+
+mod service;
 
 #[cfg(feature = "server")]
 pub mod server;
-
-mod codec;
-mod frame;
-mod service;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,10 +27,10 @@ pub mod sync {
 }
 
 ///////////////////////////////////////////////////////////////////
-/// Structs
+/// Types
 ///////////////////////////////////////////////////////////////////
-pub use crate::frame::{Request, Response};
-pub use crate::slave::{Slave, SlaveId};
+pub use crate::{Request, Response};
+pub use crate::{Slave, SlaveId};
 
 #[cfg(feature = "server")]
 pub use crate::frame::SlaveRequest;


### PR DESCRIPTION
The documentation contains important information like 0-based addressing!

Publishing `Coil` and `Word` wouldn't help and the documentation mentions their _on-the-wire_ representation that doesn't matter here.

The separate `prelude` module does not need to be extended. Let's just keep those symbols directly in the `tokio_modbus` root namespace.

### Before

```rust
pub enum Request {
    ReadCoils(u16, u16),
    ReadDiscreteInputs(u16, u16),
    WriteSingleCoil(u16, bool),
    WriteMultipleCoils(u16, Vec<bool>),
    ReadInputRegisters(u16, u16),
    ReadHoldingRegisters(u16, u16),
    WriteSingleRegister(u16, u16),
    WriteMultipleRegisters(u16, Vec<u16>),
    MaskWriteRegister(u16, u16, u16),
    ReadWriteMultipleRegisters(u16, u16, u16, Vec<u16>),
    Custom(u8, Vec<u8>),
    Disconnect,
}
```

### After

```rust
pub enum Request {
    ReadCoils(Address, Quantity),
    ReadDiscreteInputs(Address, Quantity),
    WriteSingleCoil(Address, bool),
    WriteMultipleCoils(Address, Vec<bool>),
    ReadInputRegisters(Address, Quantity),
    ReadHoldingRegisters(Address, Quantity),
    WriteSingleRegister(Address, u16),
    WriteMultipleRegisters(Address, Vec<u16>),
    MaskWriteRegister(Address, u16, u16),
    ReadWriteMultipleRegisters(Address, Quantity, Address, Vec<u16>),
    Custom(FunctionCode, Vec<u8>),
    Disconnect,
}
```