### PR TITLE
Revise server features

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
           targets: ${{ matrix.target }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
           components: clippy, rustfmt

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -20,7 +20,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: check-github-actions
       - id: check-github-workflows
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.5
+    rev: v3.0.0-alpha.6
     hooks:
       - id: prettier
         types_or:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: check-github-actions
       - id: check-github-workflows
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
+    rev: v3.0.0-alpha.5
     hooks:
       - id: prettier
         types_or:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,16 @@
 
 # Changelog
 
+## v0.8.0 (Unreleased)
+
+- TCP Server: Replace `NewService` trait with closures and never panic
+- TCP Server: Stabilize "tcp-server" feature
+- RTU Server: Remove `NewService` trait and pass instance directly
+
 ## v0.7.1 (2023-02-28)
 
 - Fix (sync): Panic when using client-side timeouts [#155](https://github.com/slowtec/tokio-modbus/issues/155)
-- tcp-server-unstable: Upgrade socket2 dependency
+- tcp-server: Upgrade socket2 dependency
 
 ## v0.7.0 (2023-02-14)
 
@@ -47,7 +53,7 @@
 ## v0.5.1 (2021-11-21)
 
 - Fix: require tokio/rt for sync feature
-- Changed: Update methods on TCP server to be async (only concerns `tcp-server-unstable` feature)
+- Changed: Update methods on TCP server to be async (only concerns `tcp-server` feature)
 
 ## v0.5.0 (2021-08-20)
 
@@ -73,7 +79,7 @@
 - Make `Exception` and `ExceptionResponse` public
 - Fixed `WriteSingleCoil` response to include data
 - Hide server traits `Service`/`NewService` traits behind `server` feature
-- Hide TCP server implementation behind `tcp-server-unstable` feature
+- Hide TCP server implementation behind `tcp-server` feature
 - Improved documentation
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ all-features = true
 # <https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277>
 
 [dependencies]
-async-trait = "0.1.64"
+async-trait = "0.1.65"
 byteorder = "1.4.3"
 bytes = "1.4.0"
 futures = { version = "0.3.26", optional = true }
@@ -31,7 +31,7 @@ futures-util = { version = "0.3.26", optional = true, default-features = false }
 log = "0.4.17"
 smallvec = { version = "1.10.0", default-features = false }
 socket2 = { version = "0.5.1", optional = true, default-features = false }
-tokio = { version = "1.25.0", default-features = false }
+tokio = { version = "1.26.0", default-features = false }
 # Disable default-features to exclude unused dependency on libudev
 tokio-serial = { version = "5.4.4", optional = true, default-features = false }
 tokio-util = { version = "0.7.7", default-features = false, features = [
@@ -39,9 +39,10 @@ tokio-util = { version = "0.7.7", default-features = false, features = [
 ] }
 
 [dev-dependencies]
+anyhow = "1.0.69"
 env_logger = "0.10.0"
 futures = "0.3.26"
-tokio = { version = "1.25.0", default-features = false, features = [
+tokio = { version = "1.26.0", default-features = false, features = [
     "macros",
     "rt-multi-thread",
     "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "tokio-modbus"
 description = "Tokio-based Modbus library"
-version = "0.7.1"
+version = "0.8.0"
 authors = [
     "slowtec GmbH <post@slowtec.de>",
     "Markus Kohlhase <markus.kohlhase@slowtec.de>",
@@ -50,13 +50,13 @@ tokio = { version = "1.26.0", default-features = false, features = [
 tokio-serial = { version = "5.4.4", default-features = false }
 
 [features]
-default = ["rtu", "tcp"]
+default = ["rtu", "tcp", "rtu-server", "tcp-server"]
 rtu = ["futures-util/sink"]
 tcp = ["tokio/net", "futures-util/sink"]
 rtu-sync = ["rtu", "sync", "dep:tokio-serial"]
 tcp-sync = ["tcp", "sync"]
 rtu-server = ["rtu", "server", "tokio/macros", "dep:tokio-serial"]
-tcp-server-unstable = [
+tcp-server = [
     "tcp",
     "server",
     "socket2/all",
@@ -108,4 +108,4 @@ required-features = ["tcp"]
 [[example]]
 name = "tcp-server"
 path = "examples/tcp-server.rs"
-required-features = ["tcp-server-unstable"]
+required-features = ["tcp-server"]

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ cargo test --workspace --all-features
 
 ## Protocol-Specification
 
-- [MODBUS Application Protocol Specification v1.1b3 (PDF)](http://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf)
-- [MODBUS over serial line specification and implementation guide v1.02 (PDF)](http://modbus.org/docs/Modbus_over_serial_line_V1_02.pdf)
-- [MODBUS Messaging on TCP/IP Implementation Guide v1.0b (PDF)](http://modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf)
+- [Modbus Application Protocol Specification v1.1b3 (PDF)](http://modbus.org/docs/Modbus_Application_Protocol_V1_1b3.pdf)
+- [Modbus over serial line specification and implementation guide v1.02 (PDF)](http://modbus.org/docs/Modbus_over_serial_line_V1_02.pdf)
+- [Modbus Messaging on TCP/IP Implementation Guide v1.0b (PDF)](http://modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ tokio-modbus = "*"
 - `"rtu-sync`: Synchronous RTU client
 - `"tcp-sync"`: Synchronous TCP client
 - `"rtu-server"`: (Asynchronous) RTU server
-- `"tcp-server-unstable"`: (Asynchronous) TCP server (experimental)
+- `"tcp-server"`: (Asynchronous) TCP server
 
 #### Examples
 
@@ -75,7 +75,7 @@ For a TCP server:
 
 ```toml
 [dependencies]
-tokio-modbus = { version = "*", default-features = false, features = ["tcp-server-unstable"] }
+tokio-modbus = { version = "*", default-features = false, features = ["tcp-server"] }
 ```
 
 ## Examples

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -11,8 +11,8 @@ use smallvec::SmallVec;
 use std::io::{Cursor, Error, ErrorKind, Result};
 use tokio_util::codec::{Decoder, Encoder};
 
-// [MODBUS over Serial Line Specification and Implementation Guide V1.02](http://modbus.org/docs/Modbus_over_serial_line_V1_02.pdf), page 13
-// "The maximum size of a MODBUS RTU frame is 256 bytes."
+// [Modbus over Serial Line Specification and Implementation Guide V1.02](http://modbus.org/docs/Modbus_over_serial_line_V1_02.pdf), page 13
+// "The maximum size of a Modbus RTU frame is 256 bytes."
 const MAX_FRAME_LEN: usize = 256;
 
 type DroppedBytes = SmallVec<[u8; MAX_FRAME_LEN]>;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9,9 +9,18 @@
 #[cfg(feature = "rtu-server")]
 pub mod rtu;
 
-#[cfg(feature = "tcp-server-unstable")]
+#[cfg(feature = "tcp-server")]
 pub mod tcp;
 
 mod service;
+pub use self::service::Service;
 
-pub use service::{NewService, Service};
+/// Cause for termination
+#[derive(Debug, Clone)]
+pub enum Terminated {
+    /// The server has finished processing.
+    Finished,
+
+    /// Processing has been aborted.
+    Aborted,
+}

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2017-2023 slowtec GmbH <post@slowtec.de>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{future::Future, io, rc::Rc, sync::Arc};
+use std::future::Future;
 
 /// A Modbus server service.
 pub trait Service {
@@ -19,92 +19,4 @@ pub trait Service {
 
     /// Process the request and return the response asynchronously.
     fn call(&self, req: Self::Request) -> Self::Future;
-}
-
-/// Creates new `Service` values.
-pub trait NewService {
-    /// Requests handled by the service
-    type Request;
-
-    /// Responses given by the service
-    type Response;
-
-    /// Errors produced by the service
-    type Error;
-
-    /// The `Service` value created by this factory
-    type Instance: Service<Request = Self::Request, Response = Self::Response, Error = Self::Error>;
-
-    /// Create and return a new service value.
-    fn new_service(&self) -> io::Result<Self::Instance>;
-}
-
-impl<F, R> NewService for F
-where
-    F: Fn() -> io::Result<R>,
-    R: Service,
-{
-    type Request = R::Request;
-    type Response = R::Response;
-    type Error = R::Error;
-    type Instance = R;
-
-    fn new_service(&self) -> io::Result<R> {
-        (*self)()
-    }
-}
-
-impl<S: NewService + ?Sized> NewService for Arc<S> {
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Instance = S::Instance;
-
-    fn new_service(&self) -> io::Result<S::Instance> {
-        (**self).new_service()
-    }
-}
-
-impl<S: NewService + ?Sized> NewService for Rc<S> {
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Instance = S::Instance;
-
-    fn new_service(&self) -> io::Result<S::Instance> {
-        (**self).new_service()
-    }
-}
-
-impl<S: Service + ?Sized + 'static> Service for Box<S> {
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    fn call(&self, request: S::Request) -> Self::Future {
-        (**self).call(request)
-    }
-}
-
-impl<S: Service + ?Sized + 'static> Service for Rc<S> {
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    fn call(&self, request: S::Request) -> Self::Future {
-        (**self).call(request)
-    }
-}
-
-impl<S: Service + ?Sized + 'static> Service for Arc<S> {
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    fn call(&self, request: S::Request) -> Self::Future {
-        (**self).call(request)
-    }
 }

--- a/src/slave.rs
+++ b/src/slave.rs
@@ -41,9 +41,9 @@ impl Slave {
     /// connected Modbus TCP device, i.e. if not forwarded through
     /// a TCP/RTU gateway according to the unit identifier.
     ///
-    /// [MODBUS Messaging on TCP/IP Implementation Guide](http://www.modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf), page 23
-    /// "On TCP/IP, the MODBUS server is addressed using its IP address; therefore,
-    /// the MODBUS Unit Identifier is useless. The value 0xFF has to be used."
+    /// [Modbus Messaging on TCP/IP Implementation Guide](http://www.modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf), page 23
+    /// "On TCP/IP, the Modbus server is addressed using its IP address; therefore,
+    /// the Modbus Unit Identifier is useless. The value 0xFF has to be used."
     #[must_use]
     pub const fn tcp_device() -> Self {
         Slave(255)


### PR DESCRIPTION
The current design is both too opinionated and inflexible.

- Stabilizes "tcp-server-unstable" as "tcp-server"
- Obsoletes #134
- Fixes #133
- Obsoletes #151
- Fixes #115