### PR TITLE
Encoding of a request into bytes might fail

### DIFF
--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -347,7 +347,7 @@ impl Encoder<RequestAdu> for ClientCodec {
             ));
         }
         let RequestAdu { hdr, pdu, .. } = adu;
-        let pdu_data: Bytes = pdu.into();
+        let pdu_data: Bytes = pdu.try_into()?;
         buf.reserve(pdu_data.len() + 3);
         buf.put_u8(hdr.slave_id);
         buf.put_slice(&pdu_data);

--- a/src/codec/tcp.rs
+++ b/src/codec/tcp.rs
@@ -144,7 +144,7 @@ impl Encoder<RequestAdu> for ClientCodec {
             ));
         }
         let RequestAdu { hdr, pdu, .. } = adu;
-        let pdu_data: Bytes = pdu.into();
+        let pdu_data: Bytes = pdu.try_into()?;
         buf.reserve(pdu_data.len() + 7);
         buf.put_u16(hdr.transaction_id);
         buf.put_u16(PROTOCOL_ID);
@@ -293,7 +293,7 @@ mod tests {
             assert_eq!(buf[6], UNIT_ID);
 
             let _ = buf.split_to(7);
-            let pdu: Bytes = req.into();
+            let pdu: Bytes = req.try_into().unwrap();
             assert_eq!(buf, pdu);
         }
 


### PR DESCRIPTION
- Prerequisite for #40/#58 and #112.
- Allowing this conversion to fail does not affect the public API