### PR TITLE
Use AsyncRead/AsyncWrite traits for generic TCP implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - TCP Server: Stabilize "tcp-server" feature
 - TCP Client: Allow to attach a generic transport layer, e.g. for TLS support
 - RTU Server: Remove `NewService` trait and pass instance directly
+- Fix (sync): No timeout while establishing serial RTU connections
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - TCP Server: Replace `NewService` trait with closures and never panic
 - TCP Server: Stabilize "tcp-server" feature
+- TCP Client: Allow to attach a generic transport layer, e.g. for TLS support
 - RTU Server: Remove `NewService` trait and pass instance directly
 
 ## v0.7.1 (2023-02-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 - TCP Client: Allow to attach a generic transport layer, e.g. for TLS support
 - RTU Server: Remove `NewService` trait and pass instance directly
 
+### Breaking Changes
+
+- RTU: Replaced the async and fallible `connect()` and `connect_slave()`
+  functions with synchronous and infallible variants named `attach()` and
+  `attach_slave()` in correspondence to their TCP counterparts.
+
 ## v0.7.1 (2023-02-28)
 
 - Fix (sync): Panic when using client-side timeouts [#155](https://github.com/slowtec/tokio-modbus/issues/155)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ all-features = true
 # <https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277>
 
 [dependencies]
-async-trait = "0.1.65"
+async-trait = "0.1.66"
 byteorder = "1.4.3"
 bytes = "1.4.0"
 futures = { version = "0.3.26", optional = true }

--- a/examples/rtu-client.rs
+++ b/examples/rtu-client.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let builder = tokio_serial::new(tty_path, 19200);
     let port = SerialStream::open(&builder).unwrap();
 
-    let mut ctx = rtu::connect_slave(port, slave).await?;
+    let mut ctx = rtu::attach_slave(port, slave);
     println!("Reading a sensor value");
     let rsp = ctx.read_holding_registers(0x082B, 2).await?;
     println!("Sensor value is: {rsp:?}");

--- a/examples/rtu-server-address.rs
+++ b/examples/rtu-server-address.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Connecting client...");
     let client_serial = tokio_serial::SerialStream::open(&builder).unwrap();
-    let mut ctx = rtu::connect_slave(client_serial, slave).await?;
+    let mut ctx = rtu::attach_slave(client_serial, slave);
     println!("Reading input registers...");
     let rsp = ctx.read_input_registers(0x00, 7).await?;
     println!("The result is '{rsp:#x?}'"); // The result is '[0x0,0x0,0x77,0x0,0x0,0x0,0x0,]'

--- a/examples/rtu-server.rs
+++ b/examples/rtu-server.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Connecting client...");
     let client_serial = tokio_serial::SerialStream::open(&builder).unwrap();
-    let mut ctx = rtu::connect(client_serial).await?;
+    let mut ctx = rtu::attach(client_serial);
     println!("Reading input registers...");
     let rsp = ctx.read_input_registers(0x00, 7).await?;
     println!("The result is '{rsp:#x?}'"); // The result is '[0x0,0x0,0x77,0x0,0x0,0x0,0x0,]'

--- a/src/client/rtu.rs
+++ b/src/client/rtu.rs
@@ -3,30 +3,26 @@
 
 //! RTU client connections
 
-use super::*;
-
-use crate::service;
-
-use std::io::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
+
+use super::*;
 
 /// Connect to no particular Modbus slave device for sending
 /// broadcast messages.
-pub async fn connect<T>(transport: T) -> Result<Context, Error>
+pub fn attach<T>(transport: T) -> Context
 where
     T: AsyncRead + AsyncWrite + Debug + Unpin + Send + 'static,
 {
-    connect_slave(transport, Slave::broadcast()).await
+    attach_slave(transport, Slave::broadcast())
 }
 
 /// Connect to any kind of Modbus slave device.
-pub async fn connect_slave<T>(transport: T, slave: Slave) -> Result<Context, Error>
+pub fn attach_slave<T>(transport: T, slave: Slave) -> Context
 where
     T: AsyncRead + AsyncWrite + Debug + Unpin + Send + 'static,
 {
-    let client = service::rtu::connect_slave(transport, slave).await?;
-
-    Ok(Context {
+    let client = crate::service::rtu::Client::new(transport, slave);
+    Context {
         client: Box::new(client),
-    })
+    }
 }


### PR DESCRIPTION
- Fixes #119
- See the changelog for the many changes

Going through the code revealed inconsistencies, bugs, and the unneeded use of `async` and `Result`.