### PR TITLE
Only include selected files in the package published on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["fieldbus", "modbus", "hardware", "automation"]
 homepage = "https://github.com/slowtec/tokio-modbus"
 repository = "https://github.com/slowtec/tokio-modbus"
 edition = "2021"
+include = ["src", "CHANGELOG.md", "README.md", "LICENSES"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields

The examples don't need to be published in the package to minimize its size.