### PR TITLE
Max retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - RTU Server: Remove `NewService` trait and pass instance directly
 - Fix (sync): No timeout while establishing serial RTU connections
 - Add: TLS client and server examples
+- Fix: Limit retrying Modbus RTU communication to 20 times instead of looping infinitely
+- Increase Minimum Supported Rust Version to 1.65
 
 ### Breaking Changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["fieldbus", "modbus", "hardware", "automation"]
 homepage = "https://github.com/slowtec/tokio-modbus"
 repository = "https://github.com/slowtec/tokio-modbus"
 edition = "2021"
+rust-version = "1.65"
 include = ["/src", "/CHANGELOG.md", "/README.md", "/LICENSES"]
 
 [package.metadata.docs.rs]

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -246,12 +246,12 @@ where
     for _i in 0..MAX_RETRIES {
         match get_pdu_len(buf) {
             Ok(pdu_len) => {
-                if let Some(pdu_len) = pdu_len {
-                    return frame_decoder.decode(buf, pdu_len);
-                } else {
+                let Some(pdu_len) = pdu_len else {
                     // Incomplete frame
                     return Ok(None);
-                }
+                };
+
+                return frame_decoder.decode(buf, pdu_len);
             }
             Err(err) => {
                 log::warn!("Failed to decode {} frame: {}", pdu_type, err);


### PR DESCRIPTION
As suggested in #184, I've fixed the infinite loop when reading from a broken Modbus RTU bus by introducing a maximum number of retries. When that number is reached, the code gives up and returns an error to the caller.

`MAX_RETRIES` is a constant that is set to 20 for now. Feel free to change that or make it configurable.

I had to edit other parts of the RTU code, which assumed that decoding can never fail. I took the opportunity to make them more readable and more consistent with the TCP code. Should get obvious when you check this PR commit by commit.

Let me know if this can go through or if there's anything I have to change.

Fixes #184 