### PR TITLE
Since modbus RTU is a request and response protocol, make sure the read buffer is always clear before sending another request

### DIFF
--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -52,6 +52,9 @@ where
         let req_adu = self.next_request_adu(req, disconnect);
         let req_hdr = req_adu.hdr;
 
+        let read_buffer = self.framed.read_buffer_mut();
+        read_buffer.clear();
+
         self.framed.send(req_adu).await?;
         let res_adu = self
             .framed


### PR DESCRIPTION
I had a lot of problems with errors in the async RTU client. Erros such:
kind: InvalidData, error: "Too many retries"
Kind(BrokenPipe)

After that fix, never got any erros in the same setup.