### PR TITLE
Clear rx buffer before call

### DIFF
--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -52,6 +52,8 @@ where
         let req_adu = self.next_request_adu(req, disconnect);
         let req_hdr = req_adu.hdr;
 
+        self.framed.read_buffer_mut().clear();
+
         self.framed.send(req_adu).await?;
         let res_adu = self
             .framed

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -74,6 +74,8 @@ where
         let req_adu = self.next_request_adu(req, disconnect);
         let req_hdr = req_adu.hdr;
 
+        self.framed.read_buffer_mut().clear();
+
         self.framed.send(req_adu).await?;
         let res_adu = self
             .framed


### PR DESCRIPTION
This helps with error recovery on unreliable physical connections.

An older version of this workaround was running for over 2 years now in several industrial installations

Relates to #60
