### PR TITLE
Request: Do not allocate a temporay `Vec` when writing multiple coils/registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 # Changelog
 
+## v0.9.0 (Unreleased)
+
+- Avoid allocations when writing multiple coils/registers
+
+### Breaking Changes
+
+- `Request` requires a lifetime and stores multiple coils/registers wrapped into `Cow`.
+
 ## v0.8.2 (2023-06-15)
 
 - Clear rx buffer before sending to help with error recovery on unreliable physical connections [#198](https://github.com/slowtec/tokio-modbus/pull/198)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "tokio-modbus"
 description = "Tokio-based Modbus library"
-version = "0.8.2"
+version = "0.9.0"
 authors = [
     "slowtec GmbH <post@slowtec.de>",
     "Markus Kohlhase <markus.kohlhase@slowtec.de>",

--- a/examples/rtu-server-address.rs
+++ b/examples/rtu-server-address.rs
@@ -14,7 +14,7 @@ struct Service {
 }
 
 impl tokio_modbus::server::Service for Service {
-    type Request = SlaveRequest;
+    type Request = SlaveRequest<'static>;
     type Response = Option<Response>;
     type Error = std::io::Error;
     type Future = future::Ready<Result<Self::Response, Self::Error>>;

--- a/examples/rtu-server.rs
+++ b/examples/rtu-server.rs
@@ -12,7 +12,7 @@ use tokio_modbus::{prelude::*, server::rtu::Server};
 struct Service;
 
 impl tokio_modbus::server::Service for Service {
-    type Request = SlaveRequest;
+    type Request = SlaveRequest<'static>;
     type Response = Response;
     type Error = std::io::Error;
     type Future = future::Ready<Result<Self::Response, Self::Error>>;

--- a/examples/tcp-client-custom-fn.rs
+++ b/examples/tcp-client-custom-fn.rs
@@ -3,6 +3,8 @@
 
 //! Custom function client example
 
+use std::borrow::Cow;
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use tokio_modbus::prelude::*;
@@ -12,7 +14,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut ctx = tcp::connect(socket_addr).await?;
 
     println!("Fetching the coupler ID");
-    let rsp = ctx.call(Request::Custom(0x66, vec![0x11, 0x42])).await?;
+    let rsp = ctx
+        .call(Request::Custom(0x66, Cow::Borrowed(&[0x11, 0x42])))
+        .await?;
 
     match rsp {
         Response::Custom(f, rsp) => {

--- a/examples/tcp-server.rs
+++ b/examples/tcp-server.rs
@@ -27,7 +27,7 @@ struct ExampleService {
 }
 
 impl tokio_modbus::server::Service for ExampleService {
-    type Request = Request;
+    type Request = Request<'static>;
     type Response = Response;
     type Error = std::io::Error;
     type Future = future::Ready<Result<Self::Response, Self::Error>>;

--- a/examples/tls-server.rs
+++ b/examples/tls-server.rs
@@ -77,7 +77,7 @@ struct ExampleService {
 }
 
 impl tokio_modbus::server::Service for ExampleService {
-    type Request = Request;
+    type Request = Request<'static>;
     type Response = Response;
     type Error = std::io::Error;
     type Future = future::Ready<Result<Self::Response, Self::Error>>;

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -292,10 +292,10 @@ impl Decoder for ClientCodec {
 }
 
 impl Decoder for ServerCodec {
-    type Item = RequestAdu;
+    type Item = RequestAdu<'static>;
     type Error = Error;
 
-    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<RequestAdu>> {
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<RequestAdu<'static>>> {
         let Some((slave_id, pdu_data)) = self.decoder.decode(buf)? else {
             return Ok(None)
         };
@@ -321,10 +321,10 @@ impl Decoder for ServerCodec {
     }
 }
 
-impl Encoder<RequestAdu> for ClientCodec {
+impl<'a> Encoder<RequestAdu<'a>> for ClientCodec {
     type Error = Error;
 
-    fn encode(&mut self, adu: RequestAdu, buf: &mut BytesMut) -> Result<()> {
+    fn encode(&mut self, adu: RequestAdu<'a>, buf: &mut BytesMut) -> Result<()> {
         if adu.disconnect {
             // The disconnect happens implicitly after letting this request
             // fail by returning an error. This will drop the attached

--- a/src/codec/tcp.rs
+++ b/src/codec/tcp.rs
@@ -113,10 +113,10 @@ impl Decoder for ClientCodec {
 }
 
 impl Decoder for ServerCodec {
-    type Item = RequestAdu;
+    type Item = RequestAdu<'static>;
     type Error = Error;
 
-    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<RequestAdu>> {
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<RequestAdu<'static>>> {
         if let Some((hdr, pdu_data)) = self.decoder.decode(buf)? {
             let pdu = RequestPdu::try_from(pdu_data)?;
             Ok(Some(RequestAdu {
@@ -130,10 +130,10 @@ impl Decoder for ServerCodec {
     }
 }
 
-impl Encoder<RequestAdu> for ClientCodec {
+impl<'a> Encoder<RequestAdu<'a>> for ClientCodec {
     type Error = Error;
 
-    fn encode(&mut self, adu: RequestAdu, buf: &mut BytesMut) -> Result<()> {
+    fn encode(&mut self, adu: RequestAdu<'a>, buf: &mut BytesMut) -> Result<()> {
         if adu.disconnect {
             // The disconnect happens implicitly after letting this request
             // fail by returning an error. This will drop the attached

--- a/src/frame/rtu.rs
+++ b/src/frame/rtu.rs
@@ -11,9 +11,9 @@ pub(crate) struct Header {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RequestAdu {
+pub struct RequestAdu<'a> {
     pub(crate) hdr: Header,
-    pub(crate) pdu: RequestPdu,
+    pub(crate) pdu: RequestPdu<'a>,
     pub(crate) disconnect: bool,
 }
 
@@ -23,15 +23,15 @@ pub(crate) struct ResponseAdu {
     pub(crate) pdu: ResponsePdu,
 }
 
-impl From<RequestAdu> for Request {
-    fn from(from: RequestAdu) -> Self {
+impl<'a> From<RequestAdu<'a>> for Request<'a> {
+    fn from(from: RequestAdu<'a>) -> Self {
         from.pdu.into()
     }
 }
 
 #[cfg(feature = "server")]
-impl From<RequestAdu> for SlaveRequest {
-    fn from(from: RequestAdu) -> Self {
+impl<'a> From<RequestAdu<'a>> for SlaveRequest<'a> {
+    fn from(from: RequestAdu<'a>) -> Self {
         Self {
             slave: from.hdr.slave_id,
             request: from.pdu.into(),

--- a/src/frame/tcp.rs
+++ b/src/frame/tcp.rs
@@ -13,9 +13,9 @@ pub(crate) struct Header {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RequestAdu {
+pub struct RequestAdu<'a> {
     pub(crate) hdr: Header,
-    pub(crate) pdu: RequestPdu,
+    pub(crate) pdu: RequestPdu<'a>,
     pub(crate) disconnect: bool,
 }
 
@@ -25,15 +25,15 @@ pub(crate) struct ResponseAdu {
     pub(crate) pdu: ResponsePdu,
 }
 
-impl From<RequestAdu> for Request {
-    fn from(from: RequestAdu) -> Self {
+impl<'a> From<RequestAdu<'a>> for Request<'a> {
+    fn from(from: RequestAdu<'a>) -> Self {
         from.pdu.into()
     }
 }
 
 #[cfg(feature = "server")]
-impl From<RequestAdu> for SlaveRequest {
-    fn from(from: RequestAdu) -> Self {
+impl<'a> From<RequestAdu<'a>> for SlaveRequest<'a> {
+    fn from(from: RequestAdu<'a>) -> Self {
         Self {
             slave: from.hdr.unit_id,
             request: from.pdu.into(),

--- a/src/server/rtu.rs
+++ b/src/server/rtu.rs
@@ -44,7 +44,7 @@ impl Server {
     pub async fn serve_forever<S>(self, service: S) -> io::Result<()>
     where
         S: Service + Send + Sync + 'static,
-        S::Request: From<RequestAdu> + Send,
+        S::Request: From<RequestAdu<'static>> + Send,
         S::Response: Into<OptionalResponsePdu> + Send,
         S::Error: Into<io::Error>,
     {
@@ -59,7 +59,7 @@ impl Server {
     pub async fn serve_until<S, X>(self, service: S, abort_signal: X) -> io::Result<Terminated>
     where
         S: Service + Send + Sync + 'static,
-        S::Request: From<RequestAdu> + Send,
+        S::Request: From<RequestAdu<'static>> + Send,
         S::Response: Into<OptionalResponsePdu> + Send,
         S::Error: Into<io::Error>,
         X: Future<Output = ()> + Sync + Send + Unpin + 'static,
@@ -84,7 +84,7 @@ async fn process<S, Req, Res>(
 ) -> io::Result<()>
 where
     S: Service<Request = Req, Response = Res> + Send + Sync + 'static,
-    S::Request: From<RequestAdu> + Send,
+    S::Request: From<RequestAdu<'static>> + Send,
     S::Response: Into<OptionalResponsePdu> + Send,
     S::Error: Into<io::Error>,
 {

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -41,7 +41,7 @@ pub fn accept_tcp_connection<S, NewService>(
 ) -> io::Result<Option<(S, TcpStream)>>
 where
     S: Service + Send + Sync + 'static,
-    S::Request: From<RequestAdu> + Send,
+    S::Request: From<RequestAdu<'static>> + Send,
     S::Response: Into<OptionalResponsePdu> + Send,
     S::Error: Into<io::Error>,
     NewService: Fn(SocketAddr) -> io::Result<Option<S>>,
@@ -77,7 +77,7 @@ impl Server {
     ) -> io::Result<()>
     where
         S: Service + Send + Sync + 'static,
-        S::Request: From<RequestAdu> + Send,
+        S::Request: From<RequestAdu<'static>> + Send,
         S::Response: Into<OptionalResponsePdu> + Send,
         S::Error: Into<io::Error>,
         T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -118,7 +118,7 @@ impl Server {
     ) -> io::Result<Terminated>
     where
         S: Service + Send + Sync + 'static,
-        S::Request: From<RequestAdu> + Send,
+        S::Request: From<RequestAdu<'static>> + Send,
         S::Response: Into<OptionalResponsePdu> + Send,
         S::Error: Into<io::Error>,
         T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -143,7 +143,7 @@ impl Server {
 async fn process<S, T, Req, Res>(mut framed: Framed<T, ServerCodec>, service: S) -> io::Result<()>
 where
     S: Service<Request = Req, Response = Res> + Send + Sync + 'static,
-    S::Request: From<RequestAdu> + Send,
+    S::Request: From<RequestAdu<'static>> + Send,
     S::Response: Into<OptionalResponsePdu> + Send,
     S::Error: Into<io::Error>,
     T: AsyncRead + AsyncWrite + Unpin,
@@ -222,7 +222,7 @@ mod tests {
         }
 
         impl Service for DummyService {
-            type Request = Request;
+            type Request = Request<'static>;
             type Response = Response;
             type Error = io::Error;
             type Future = future::Ready<Result<Self::Response, Self::Error>>;
@@ -257,7 +257,7 @@ mod tests {
         }
 
         impl Service for DummyService {
-            type Request = Request;
+            type Request = Request<'static>;
             type Response = Response;
             type Error = io::Error;
             type Future = future::Ready<Result<Self::Response, Self::Error>>;

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -33,9 +33,9 @@ where
         Self { framed, slave_id }
     }
 
-    fn next_request_adu<R>(&self, req: R, disconnect: bool) -> RequestAdu
+    fn next_request_adu<'a, R>(&self, req: R, disconnect: bool) -> RequestAdu<'a>
     where
-        R: Into<RequestPdu>,
+        R: Into<RequestPdu<'a>>,
     {
         let slave_id = self.slave_id;
         let hdr = Header { slave_id };
@@ -47,7 +47,7 @@ where
         }
     }
 
-    async fn call(&mut self, req: Request) -> Result<Response, Error> {
+    async fn call(&mut self, req: Request<'_>) -> Result<Response, Error> {
         let disconnect = req == Request::Disconnect;
         let req_adu = self.next_request_adu(req, disconnect);
         let req_hdr = req_adu.hdr;
@@ -91,7 +91,7 @@ impl<T> crate::client::Client for Client<T>
 where
     T: fmt::Debug + AsyncRead + AsyncWrite + Send + Unpin,
 {
-    async fn call(&mut self, req: Request) -> Result<Response, Error> {
+    async fn call(&mut self, req: Request<'_>) -> Result<Response, Error> {
         self.call(req).await
     }
 }

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -57,9 +57,9 @@ where
         }
     }
 
-    fn next_request_adu<R>(&self, req: R, disconnect: bool) -> RequestAdu
+    fn next_request_adu<'a, R>(&self, req: R, disconnect: bool) -> RequestAdu<'a>
     where
-        R: Into<RequestPdu>,
+        R: Into<RequestPdu<'a>>,
     {
         RequestAdu {
             hdr: self.next_request_hdr(self.unit_id),
@@ -68,7 +68,7 @@ where
         }
     }
 
-    pub(crate) async fn call(&mut self, req: Request) -> Result<Response, Error> {
+    pub(crate) async fn call(&mut self, req: Request<'_>) -> Result<Response, Error> {
         log::debug!("Call {:?}", req);
         let disconnect = req == Request::Disconnect;
         let req_adu = self.next_request_adu(req, disconnect);
@@ -113,7 +113,7 @@ impl<T> crate::client::Client for Client<T>
 where
     T: fmt::Debug + AsyncRead + AsyncWrite + Send + Unpin,
 {
-    async fn call(&mut self, req: Request) -> Result<Response, Error> {
+    async fn call(&mut self, req: Request<'_>) -> Result<Response, Error> {
         Client::call(self, req).await
     }
 }


### PR DESCRIPTION
Fixes #205.

It turned out that the temporary allocations are not needed. Passing a borrowed slice is fine.

The traits didn't change. Only `Request` requires a lifetime parameter.

### TODO

- [x] Rebase after #206 has been merged.