### PR TITLE
Response::Custom: Return payload as Bytes instead of Vec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 
 ## v0.9.0 (Unreleased)
 
-- Avoid allocations when writing multiple coils/registers
+- Optimization: Avoid allocations when writing multiple coils/registers.
+- Optimization: Avoid allocations when receiving custom responses.
 
 ### Breaking Changes
 
-- `Request` requires a lifetime and stores multiple coils/registers wrapped into `Cow`.
+- `Request`: Requires a lifetime and stores multiple coils/registers wrapped into `Cow` to avoid allocations.
+- `Response::Custom`: The payload is returned as `Bytes` instead of `Vec` to avoid allocations.
 
 ## v0.8.2 (2023-06-15)
 

--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -1,15 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2017-2023 slowtec GmbH <post@slowtec.de>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use super::*;
-
-use crate::{frame::rtu::*, slave::SlaveId};
+use std::io::{Cursor, Error, ErrorKind, Result};
 
 use byteorder::BigEndian;
-use bytes::{Buf, BufMut, Bytes, BytesMut};
 use smallvec::SmallVec;
-use std::io::{Cursor, Error, ErrorKind, Result};
 use tokio_util::codec::{Decoder, Encoder};
+
+use crate::{
+    bytes::{Buf, BufMut, Bytes, BytesMut},
+    frame::rtu::*,
+    slave::SlaveId,
+};
+
+use super::*;
 
 // [Modbus over Serial Line Specification and Implementation Guide V1.02](http://modbus.org/docs/Modbus_over_serial_line_V1_02.pdf), page 13
 // "The maximum size of a Modbus RTU frame is 256 bytes."
@@ -364,7 +368,7 @@ impl Encoder<ResponseAdu> for ServerCodec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
+    use crate::bytes::Bytes;
 
     #[test]
     fn test_calc_crc() {

--- a/src/codec/tcp.rs
+++ b/src/codec/tcp.rs
@@ -1,14 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2017-2023 slowtec GmbH <post@slowtec.de>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use super::*;
-
-use crate::frame::tcp::*;
+use std::io::{Error, ErrorKind, Result};
 
 use byteorder::{BigEndian, ByteOrder};
-use bytes::{BufMut, Bytes, BytesMut};
-use std::io::{Error, ErrorKind, Result};
 use tokio_util::codec::{Decoder, Encoder};
+
+use crate::{
+    bytes::{BufMut, Bytes, BytesMut},
+    frame::tcp::*,
+};
+
+use super::*;
 
 const HEADER_LEN: usize = 7;
 
@@ -174,7 +177,7 @@ impl Encoder<ResponseAdu> for ServerCodec {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
+    use crate::bytes::Bytes;
 
     mod client {
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod tcp;
 
 use std::{borrow::Cow, error, fmt};
 
+use crate::bytes::Bytes;
+
 /// A Modbus function code is represented by an unsigned 8 bit integer.
 pub type FunctionCode = u8;
 
@@ -220,7 +222,7 @@ pub enum Response {
     /// Response to a raw Modbus request
     /// The first parameter contains the returned Modbus function code
     /// The second parameter contains the bytes read following the function code
-    Custom(FunctionCode, Vec<u8>),
+    Custom(FunctionCode, Bytes),
 }
 
 /// A server (slave) exception.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,13 @@
 #![warn(rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
+/// Re-export the `bytes` crate
+///
+/// Needed to prevent version conflicts with types that are exposed by the public API.
+///
+/// Used by [`Response::Custom`].
+pub use bytes;
+
 pub mod prelude;
 
 pub mod client;


### PR DESCRIPTION
An optimization for `Response::Custom`.

Notable change: The `bytes` crate is re-exported, because `bytes::Bytes` appears in the public API. This avoids conflicts when a project requires incompatible versions of this crate.

### TODO

- [x] Rebase after #207 has been merged.