### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 # Changelog
 
-## v0.9.0 (Unreleased)
+## v0.9.0 (2023-07-26)
 
 - Optimization: Avoid allocations when writing multiple coils/registers.
 - Optimization: Avoid allocations when receiving custom responses.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio-serial = { version = "5.4.4", default-features = false }
 rustls-pemfile = "1.0.3"
 tokio-rustls = "0.24.1"
 pkcs8 = { version = "0.10.2", features = ["encryption", "pem", "std"] }
-pem = "2.0.1"
+pem = "3.0.1"
 webpki = "0.22.0"
 
 [features]


### PR DESCRIPTION
Adding and pushing the `v0.9.0` tag after merging this PR should automatically publish the new release on crates.io.