### PR TITLE
Publicly export `ExceptionResponse` and `Exception` types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,9 @@ pub use self::slave::{Slave, SlaveId};
 mod codec;
 
 mod frame;
-pub use self::frame::{Address, FunctionCode, Quantity, Request, Response};
+pub use self::frame::{
+    Address, Exception, ExceptionResponse, FunctionCode, Quantity, Request, Response,
+};
 
 mod service;
 


### PR DESCRIPTION
By making these types public, one is able to get the specific modbus error from a Modbus server.

So this is a short-term solution for #169, but it's definitely not a good one.