### PR TITLE
Make frame::Exception public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub use self::slave::{Slave, SlaveId};
 mod codec;
 
 mod frame;
-pub use self::frame::{Address, FunctionCode, Quantity, Request, Response};
+pub use self::frame::{Address, Exception, FunctionCode, Quantity, Request, Response};
 
 mod service;
 


### PR DESCRIPTION
Today one has to match on the to_string() representation, which is sub-optimal to say the least.