### PR TITLE
Replace `FunctionCode` type alias with enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Breaking Changes
 
-- `FunctionCode`: Change `type alias` to an `enum`.
+- `FunctionCode`: Replace `type` alias with `enum`.
 
 ## v0.9.0 (2023-07-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 ## v0.10.0 (Unreleased)
 
 - Exclude `rtu-server`/`tcp-server` from default features.
+- Feature: Retrieve the `FunctionCode` of a `Request`/`Response`.
+
+### Breaking Changes
+
+- `FunctionCode`: Change `type alias` to an `enum`.
 
 ## v0.9.0 (2023-07-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 # Changelog
 
+## v0.10.0 (Unreleased)
+
+- Exclude `rtu-server`/`tcp-server` from default features.
+
 ## v0.9.0 (2023-07-26)
 
 - Optimization: Avoid allocations when writing multiple coils/registers.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ pem = "3.0.3"
 webpki = "0.22.4"
 
 [features]
-default = ["rtu", "tcp", "rtu-server", "tcp-server"]
+default = ["rtu", "tcp"]
 rtu = ["futures-util/sink"]
 tcp = ["tokio/net", "futures-util/sink"]
 rtu-sync = ["rtu", "sync", "dep:tokio-serial"]

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -438,23 +438,6 @@ fn unpack_coils(bytes: &[u8], count: u16) -> Vec<Coil> {
     res
 }
 
-fn rsp_to_fn_code(rsp: &Response) -> u8 {
-    use crate::frame::Response::*;
-    match *rsp {
-        ReadCoils(_) => 0x01,
-        ReadDiscreteInputs(_) => 0x02,
-        WriteSingleCoil(_, _) => 0x05,
-        WriteMultipleCoils(_, _) => 0x0F,
-        ReadInputRegisters(_) => 0x04,
-        ReadHoldingRegisters(_) => 0x03,
-        WriteSingleRegister(_, _) => 0x06,
-        WriteMultipleRegisters(_, _) => 0x10,
-        MaskWriteRegister(_, _, _) => 0x16,
-        ReadWriteMultipleRegisters(_) => 0x17,
-        Custom(code, _) => code,
-    }
-}
-
 fn request_byte_count(req: &Request<'_>) -> usize {
     use crate::frame::Request::*;
     match *req {
@@ -531,22 +514,6 @@ mod tests {
         assert_eq!(unpack_coils(&[0b10], 2), &[false, true]);
         assert_eq!(unpack_coils(&[0b101], 3), &[true, false, true]);
         assert_eq!(unpack_coils(&[0xff, 0b11], 10), &[true; 10]);
-    }
-
-    #[test]
-    fn function_code_from_response() {
-        use crate::frame::Response::*;
-        assert_eq!(rsp_to_fn_code(&ReadCoils(vec![])), 1);
-        assert_eq!(rsp_to_fn_code(&ReadDiscreteInputs(vec![])), 2);
-        assert_eq!(rsp_to_fn_code(&WriteSingleCoil(0x0, false)), 5);
-        assert_eq!(rsp_to_fn_code(&WriteMultipleCoils(0x0, 0x0)), 0x0F);
-        assert_eq!(rsp_to_fn_code(&ReadInputRegisters(vec![])), 0x04);
-        assert_eq!(rsp_to_fn_code(&ReadHoldingRegisters(vec![])), 0x03);
-        assert_eq!(rsp_to_fn_code(&WriteSingleRegister(0, 0)), 0x06);
-        assert_eq!(rsp_to_fn_code(&WriteMultipleRegisters(0, 0)), 0x10);
-        assert_eq!(rsp_to_fn_code(&MaskWriteRegister(0, 0, 0)), 0x16);
-        assert_eq!(rsp_to_fn_code(&ReadWriteMultipleRegisters(vec![])), 0x17);
-        assert_eq!(rsp_to_fn_code(&Custom(99, Bytes::from_static(&[]))), 99);
     }
 
     #[test]

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -438,24 +438,6 @@ fn unpack_coils(bytes: &[u8], count: u16) -> Vec<Coil> {
     res
 }
 
-fn req_to_fn_code(req: &Request<'_>) -> u8 {
-    use crate::frame::Request::*;
-    match *req {
-        ReadCoils(_, _) => 0x01,
-        ReadDiscreteInputs(_, _) => 0x02,
-        WriteSingleCoil(_, _) => 0x05,
-        WriteMultipleCoils(_, _) => 0x0F,
-        ReadInputRegisters(_, _) => 0x04,
-        ReadHoldingRegisters(_, _) => 0x03,
-        WriteSingleRegister(_, _) => 0x06,
-        WriteMultipleRegisters(_, _) => 0x10,
-        MaskWriteRegister(_, _, _) => 0x16,
-        ReadWriteMultipleRegisters(_, _, _, _) => 0x17,
-        Custom(code, _) => code,
-        Disconnect => unreachable!(),
-    }
-}
-
 fn rsp_to_fn_code(rsp: &Response) -> u8 {
     use crate::frame::Response::*;
     match *rsp {
@@ -549,31 +531,6 @@ mod tests {
         assert_eq!(unpack_coils(&[0b10], 2), &[false, true]);
         assert_eq!(unpack_coils(&[0b101], 3), &[true, false, true]);
         assert_eq!(unpack_coils(&[0xff, 0b11], 10), &[true; 10]);
-    }
-
-    #[test]
-    fn function_code_from_request() {
-        use crate::frame::Request::*;
-        assert_eq!(req_to_fn_code(&ReadCoils(0, 0)), 1);
-        assert_eq!(req_to_fn_code(&ReadDiscreteInputs(0, 0)), 2);
-        assert_eq!(req_to_fn_code(&WriteSingleCoil(0, true)), 5);
-        assert_eq!(
-            req_to_fn_code(&WriteMultipleCoils(0, Cow::Borrowed(&[]))),
-            0x0F
-        );
-        assert_eq!(req_to_fn_code(&ReadInputRegisters(0, 0)), 0x04);
-        assert_eq!(req_to_fn_code(&ReadHoldingRegisters(0, 0)), 0x03);
-        assert_eq!(req_to_fn_code(&WriteSingleRegister(0, 0)), 0x06);
-        assert_eq!(
-            req_to_fn_code(&WriteMultipleRegisters(0, Cow::Borrowed(&[]))),
-            0x10
-        );
-        assert_eq!(req_to_fn_code(&MaskWriteRegister(0, 0, 0)), 0x16);
-        assert_eq!(
-            req_to_fn_code(&ReadWriteMultipleRegisters(0, 0, 0, Cow::Borrowed(&[]))),
-            0x17
-        );
-        assert_eq!(req_to_fn_code(&Custom(88, Cow::Borrowed(&[]))), 88);
     }
 
     #[test]

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -45,7 +45,7 @@ impl<'a> TryFrom<Request<'a>> for Bytes {
         use crate::frame::Request::*;
         let cnt = request_byte_count(&req);
         let mut data = BytesMut::with_capacity(cnt);
-        data.put_u8(req.function_code().into());
+        data.put_u8(req.function_code().value());
         match req {
             ReadCoils(address, quantity)
             | ReadDiscreteInputs(address, quantity)
@@ -121,7 +121,7 @@ impl From<Response> for Bytes {
         use crate::frame::Response::*;
         let cnt = response_byte_count(&rsp);
         let mut data = BytesMut::with_capacity(cnt);
-        data.put_u8(rsp.function_code().into());
+        data.put_u8(rsp.function_code().value());
         match rsp {
             ReadCoils(coils) | ReadDiscreteInputs(coils) => {
                 let packed_coils = pack_coils(&coils);

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -86,18 +86,6 @@ impl FunctionCode {
     }
 }
 
-impl From<FunctionCode> for u8 {
-    fn from(fc: FunctionCode) -> Self {
-        fc.value()
-    }
-}
-
-impl From<u8> for FunctionCode {
-    fn from(value: u8) -> Self {
-        Self::new(value)
-    }
-}
-
 impl Display for FunctionCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.value())

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -7,12 +7,102 @@ pub(crate) mod rtu;
 #[cfg(feature = "tcp")]
 pub(crate) mod tcp;
 
-use std::{borrow::Cow, error, fmt};
+use std::{
+    borrow::Cow,
+    error,
+    fmt::{self, Display},
+};
 
 use crate::bytes::Bytes;
 
-/// A Modbus function code is represented by an unsigned 8 bit integer.
-pub type FunctionCode = u8;
+/// A Modbus function code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FunctionCode {
+    /// Modbus Function Code: `01` (`0x01`).
+    ReadCoils,
+    /// Modbus Function Code: `02` (`0x02`).
+    ReadDiscreteInputs,
+
+    /// Modbus Function Code: `05` (`0x05`).
+    WriteSingleCoil,
+    /// Modbus Function Code: `06` (`0x06`).
+    WriteSingleRegister,
+
+    /// Modbus Function Code: `03` (`0x03`).
+    ReadHoldingRegisters,
+    /// Modbus Function Code: `04` (`0x04`).
+    ReadInputRegisters,
+
+    /// Modbus Function Code: `15` (`0x0F`).
+    WriteMultipleCoils,
+    /// Modbus Function Code: `16` (`0x10`).
+    WriteMultipleRegisters,
+
+    /// Modbus Function Code: `22` (`0x16`).
+    MaskWriteRegister,
+
+    /// Modbus Function Code: `23` (`0x17`).
+    ReadWriteMultipleRegisters,
+
+    /// Custom Modbus Function Code.
+    Custom(u8),
+}
+
+impl FunctionCode {
+    /// Create a new [`FunctionCode`] with `value`.
+    #[must_use]
+    pub const fn new(value: u8) -> Self {
+        match value {
+            0x01 => FunctionCode::ReadCoils,
+            0x02 => FunctionCode::ReadDiscreteInputs,
+            0x05 => FunctionCode::WriteSingleCoil,
+            0x06 => FunctionCode::WriteSingleRegister,
+            0x03 => FunctionCode::ReadHoldingRegisters,
+            0x04 => FunctionCode::ReadInputRegisters,
+            0x0F => FunctionCode::WriteMultipleCoils,
+            0x10 => FunctionCode::WriteMultipleRegisters,
+            0x16 => FunctionCode::MaskWriteRegister,
+            0x17 => FunctionCode::ReadWriteMultipleRegisters,
+            code => FunctionCode::Custom(code),
+        }
+    }
+
+    /// Get the [`u8`] value of the current [`FunctionCode`].
+    #[must_use]
+    pub const fn value(self) -> u8 {
+        match self {
+            FunctionCode::ReadCoils => 0x01,
+            FunctionCode::ReadDiscreteInputs => 0x02,
+            FunctionCode::WriteSingleCoil => 0x05,
+            FunctionCode::WriteSingleRegister => 0x06,
+            FunctionCode::ReadHoldingRegisters => 0x03,
+            FunctionCode::ReadInputRegisters => 0x04,
+            FunctionCode::WriteMultipleCoils => 0x0F,
+            FunctionCode::WriteMultipleRegisters => 0x10,
+            FunctionCode::MaskWriteRegister => 0x16,
+            FunctionCode::ReadWriteMultipleRegisters => 0x17,
+            FunctionCode::Custom(code) => code,
+        }
+    }
+}
+
+impl From<FunctionCode> for u8 {
+    fn from(fc: FunctionCode) -> Self {
+        fc.value()
+    }
+}
+
+impl From<u8> for FunctionCode {
+    fn from(value: u8) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Display for FunctionCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.value())
+    }
+}
 
 /// A Modbus protocol address is represented by 16 bit from `0` to `65535`.
 ///
@@ -95,7 +185,7 @@ pub enum Request<'a> {
     /// A raw Modbus request.
     /// The first parameter is the Modbus function code.
     /// The second parameter is the raw bytes of the request.
-    Custom(FunctionCode, Cow<'a, [u8]>),
+    Custom(u8, Cow<'a, [u8]>),
 
     /// A poison pill for stopping the client service and to release
     /// the underlying transport, e.g. for disconnecting from an
@@ -136,6 +226,34 @@ impl<'a> Request<'a> {
             }
             Custom(func, bytes) => Custom(func, Cow::Owned(bytes.into_owned())),
             Disconnect => Disconnect,
+        }
+    }
+
+    /// Get the [`FunctionCode`] of the [`Request`].
+    #[must_use]
+    pub const fn function_code(&self) -> FunctionCode {
+        use Request::*;
+
+        match self {
+            ReadCoils(_, _) => FunctionCode::ReadCoils,
+            ReadDiscreteInputs(_, _) => FunctionCode::ReadDiscreteInputs,
+
+            WriteSingleCoil(_, _) => FunctionCode::WriteSingleCoil,
+            WriteMultipleCoils(_, _) => FunctionCode::WriteMultipleCoils,
+
+            ReadInputRegisters(_, _) => FunctionCode::ReadInputRegisters,
+            ReadHoldingRegisters(_, _) => FunctionCode::ReadHoldingRegisters,
+
+            WriteSingleRegister(_, _) => FunctionCode::WriteSingleRegister,
+            WriteMultipleRegisters(_, _) => FunctionCode::WriteMultipleRegisters,
+
+            MaskWriteRegister(_, _, _) => FunctionCode::MaskWriteRegister,
+
+            ReadWriteMultipleRegisters(_, _, _, _) => FunctionCode::ReadWriteMultipleRegisters,
+
+            Custom(code, _) => FunctionCode::Custom(*code),
+
+            Disconnect => unreachable!(),
         }
     }
 }
@@ -222,7 +340,35 @@ pub enum Response {
     /// Response to a raw Modbus request
     /// The first parameter contains the returned Modbus function code
     /// The second parameter contains the bytes read following the function code
-    Custom(FunctionCode, Bytes),
+    Custom(u8, Bytes),
+}
+
+impl Response {
+    /// Get the [`FunctionCode`] of the [`Response`].
+    #[must_use]
+    pub const fn function_code(&self) -> FunctionCode {
+        use Response::*;
+
+        match self {
+            ReadCoils(_) => FunctionCode::ReadCoils,
+            ReadDiscreteInputs(_) => FunctionCode::ReadDiscreteInputs,
+
+            WriteSingleCoil(_, _) => FunctionCode::WriteSingleCoil,
+            WriteMultipleCoils(_, _) => FunctionCode::WriteMultipleCoils,
+
+            ReadInputRegisters(_) => FunctionCode::ReadInputRegisters,
+            ReadHoldingRegisters(_) => FunctionCode::ReadHoldingRegisters,
+
+            WriteSingleRegister(_, _) => FunctionCode::WriteSingleRegister,
+            WriteMultipleRegisters(_, _) => FunctionCode::WriteMultipleRegisters,
+
+            MaskWriteRegister(_, _, _) => FunctionCode::MaskWriteRegister,
+
+            ReadWriteMultipleRegisters(_) => FunctionCode::ReadWriteMultipleRegisters,
+
+            Custom(code, _) => FunctionCode::Custom(*code),
+        }
+    }
 }
 
 /// A server (slave) exception.
@@ -360,5 +506,161 @@ impl fmt::Display for ExceptionResponse {
 impl error::Error for ExceptionResponse {
     fn description(&self) -> &str {
         self.exception.description()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_function_code() {
+        assert_eq!(FunctionCode::ReadCoils, FunctionCode::new(0x01));
+        assert_eq!(FunctionCode::ReadDiscreteInputs, FunctionCode::new(0x02));
+
+        assert_eq!(FunctionCode::WriteSingleCoil, FunctionCode::new(0x05));
+        assert_eq!(FunctionCode::WriteSingleRegister, FunctionCode::new(0x06));
+
+        assert_eq!(FunctionCode::ReadHoldingRegisters, FunctionCode::new(0x03));
+        assert_eq!(FunctionCode::ReadInputRegisters, FunctionCode::new(0x04));
+
+        assert_eq!(FunctionCode::WriteMultipleCoils, FunctionCode::new(0x0F));
+        assert_eq!(
+            FunctionCode::WriteMultipleRegisters,
+            FunctionCode::new(0x10)
+        );
+
+        assert_eq!(FunctionCode::MaskWriteRegister, FunctionCode::new(0x016));
+
+        assert_eq!(
+            FunctionCode::ReadWriteMultipleRegisters,
+            FunctionCode::new(0x017)
+        );
+
+        assert_eq!(FunctionCode::Custom(70), FunctionCode::new(70));
+    }
+
+    #[test]
+    fn function_code_values() {
+        assert_eq!(FunctionCode::ReadCoils.value(), 0x01);
+        assert_eq!(FunctionCode::ReadDiscreteInputs.value(), 0x02);
+
+        assert_eq!(FunctionCode::WriteSingleCoil.value(), 0x05);
+        assert_eq!(FunctionCode::WriteSingleRegister.value(), 0x06);
+
+        assert_eq!(FunctionCode::ReadHoldingRegisters.value(), 0x03);
+        assert_eq!(FunctionCode::ReadInputRegisters.value(), 0x04);
+
+        assert_eq!(FunctionCode::WriteMultipleCoils.value(), 0x0F);
+        assert_eq!(FunctionCode::WriteMultipleRegisters.value(), 0x10);
+
+        assert_eq!(FunctionCode::MaskWriteRegister.value(), 0x016);
+
+        assert_eq!(FunctionCode::ReadWriteMultipleRegisters.value(), 0x017);
+
+        assert_eq!(FunctionCode::Custom(70).value(), 70);
+    }
+
+    #[test]
+    fn function_code_from_request() {
+        use Request::*;
+
+        assert_eq!(ReadCoils(0, 0).function_code(), FunctionCode::ReadCoils);
+        assert_eq!(
+            ReadDiscreteInputs(0, 0).function_code(),
+            FunctionCode::ReadDiscreteInputs
+        );
+
+        assert_eq!(
+            WriteSingleCoil(0, true).function_code(),
+            FunctionCode::WriteSingleCoil
+        );
+        assert_eq!(
+            WriteMultipleCoils(0, Cow::Borrowed(&[])).function_code(),
+            FunctionCode::WriteMultipleCoils
+        );
+
+        assert_eq!(
+            ReadInputRegisters(0, 0).function_code(),
+            FunctionCode::ReadInputRegisters
+        );
+        assert_eq!(
+            ReadHoldingRegisters(0, 0).function_code(),
+            FunctionCode::ReadHoldingRegisters
+        );
+
+        assert_eq!(
+            WriteSingleRegister(0, 0).function_code(),
+            FunctionCode::WriteSingleRegister
+        );
+        assert_eq!(
+            WriteMultipleRegisters(0, Cow::Borrowed(&[])).function_code(),
+            FunctionCode::WriteMultipleRegisters
+        );
+
+        assert_eq!(
+            MaskWriteRegister(0, 0, 0).function_code(),
+            FunctionCode::MaskWriteRegister
+        );
+
+        assert_eq!(
+            ReadWriteMultipleRegisters(0, 0, 0, Cow::Borrowed(&[])).function_code(),
+            FunctionCode::ReadWriteMultipleRegisters
+        );
+
+        assert_eq!(Custom(88, Cow::Borrowed(&[])).function_code().value(), 88);
+    }
+
+    #[test]
+    fn function_code_from_response() {
+        use Response::*;
+
+        assert_eq!(ReadCoils(vec![]).function_code(), FunctionCode::ReadCoils);
+        assert_eq!(
+            ReadDiscreteInputs(vec![]).function_code(),
+            FunctionCode::ReadDiscreteInputs
+        );
+
+        assert_eq!(
+            WriteSingleCoil(0x0, false).function_code(),
+            FunctionCode::WriteSingleCoil
+        );
+        assert_eq!(
+            WriteMultipleCoils(0x0, 0x0).function_code(),
+            FunctionCode::WriteMultipleCoils
+        );
+
+        assert_eq!(
+            ReadInputRegisters(vec![]).function_code(),
+            FunctionCode::ReadInputRegisters
+        );
+        assert_eq!(
+            ReadHoldingRegisters(vec![]).function_code(),
+            FunctionCode::ReadHoldingRegisters
+        );
+
+        assert_eq!(
+            WriteSingleRegister(0, 0).function_code(),
+            FunctionCode::WriteSingleRegister
+        );
+        assert_eq!(
+            WriteMultipleRegisters(0, 0).function_code(),
+            FunctionCode::WriteMultipleRegisters
+        );
+
+        assert_eq!(
+            MaskWriteRegister(0, 0, 0).function_code(),
+            FunctionCode::MaskWriteRegister
+        );
+
+        assert_eq!(
+            ReadWriteMultipleRegisters(vec![]).function_code(),
+            FunctionCode::ReadWriteMultipleRegisters
+        );
+
+        assert_eq!(
+            Custom(99, Bytes::from_static(&[])).function_code().value(),
+            99
+        );
     }
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -88,7 +88,7 @@ impl FunctionCode {
 
 impl Display for FunctionCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.value())
+        self.value().fmt(f)
     }
 }
 


### PR DESCRIPTION
This PR try to improve the usability of the `FunctionCode` type by adding an enum with modbus public function code, as well a custom function code defined by the user.

The goal is to reduce code duplication and ease the use of the `FunctionCode` in order to avoid mistakes.

It also adds the ability to retrieve the `FunctionCode` associated with a `Request`/`Response`.

This will be useful in the futur when we try to implement #165 because we need to have access to the type of `Request` we are handling in case of an error in the `server`.

I took inspiration from the work in #226 .

This is a Breaking Change as we are updating a Public type.