### PR TITLE
Exclude "rtu-server"/"tcp-server" from default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 # Changelog
 
+## v0.10.0 (Unreleased)
+
+- Exclude `rtu-server`/`tcp-server` from default features.
+
 ## v0.9.0 (2023-07-26)
 
 - Optimization: Avoid allocations when writing multiple coils/registers.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ pem = "3.0.3"
 webpki = "0.22.4"
 
 [features]
-default = ["rtu", "tcp", "rtu-server", "tcp-server"]
+default = ["rtu", "tcp"]
 rtu = ["futures-util/sink"]
 tcp = ["tokio/net", "futures-util/sink"]
 rtu-sync = ["rtu", "sync", "dep:tokio-serial"]


### PR DESCRIPTION
Enabling those _experimental_ features by default was never intended.