### PR TITLE
refacto: new `Client` API

### DIFF
--- a/examples/rtu-over-tcp-server.rs
+++ b/examples/rtu-over-tcp-server.rs
@@ -168,7 +168,7 @@ async fn client_context(socket_addr: SocketAddr) {
             let mut ctx = tokio_modbus::prelude::rtu::attach_slave(transport, Slave(1));
 
             println!("CLIENT: Reading 2 input registers...");
-            let response = ctx.read_input_registers(0x00, 2).await.unwrap();
+            let response = ctx.read_input_registers(0x00, 2).await.unwrap().unwrap();
             println!("CLIENT: The result is '{response:?}'");
             assert_eq!(response, [1234, 5678]);
 
@@ -179,7 +179,7 @@ async fn client_context(socket_addr: SocketAddr) {
 
             // Read back a block including the two registers we wrote.
             println!("CLIENT: Reading 4 holding registers...");
-            let response = ctx.read_holding_registers(0x00, 4).await.unwrap();
+            let response = ctx.read_holding_registers(0x00, 4).await.unwrap().unwrap();
             println!("CLIENT: The result is '{response:?}'");
             assert_eq!(response, [10, 7777, 8888, 40]);
 

--- a/examples/tcp-client-custom-fn.rs
+++ b/examples/tcp-client-custom-fn.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Fetching the coupler ID");
     let rsp = ctx
         .call(Request::Custom(0x66, Cow::Borrowed(&[0x11, 0x42])))
-        .await?;
+        .await??;
 
     match rsp {
         Response::Custom(f, rsp) => {

--- a/examples/tcp-client.rs
+++ b/examples/tcp-client.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut ctx = tcp::connect(socket_addr).await?;
 
     println!("Fetching the coupler ID");
-    let data = ctx.read_input_registers(0x1000, 7).await?;
+    let data = ctx.read_input_registers(0x1000, 7).await??;
 
     let bytes: Vec<u8> = data.iter().fold(vec![], |mut x, elem| {
         x.push((elem & 0xff) as u8);

--- a/examples/tcp-server.rs
+++ b/examples/tcp-server.rs
@@ -168,7 +168,7 @@ async fn client_context(socket_addr: SocketAddr) {
             let mut ctx = tcp::connect(socket_addr).await.unwrap();
 
             println!("CLIENT: Reading 2 input registers...");
-            let response = ctx.read_input_registers(0x00, 2).await.unwrap();
+            let response = ctx.read_input_registers(0x00, 2).await.unwrap().unwrap();
             println!("CLIENT: The result is '{response:?}'");
             assert_eq!(response, [1234, 5678]);
 
@@ -179,7 +179,7 @@ async fn client_context(socket_addr: SocketAddr) {
 
             // Read back a block including the two registers we wrote.
             println!("CLIENT: Reading 4 holding registers...");
-            let response = ctx.read_holding_registers(0x00, 4).await.unwrap();
+            let response = ctx.read_holding_registers(0x00, 4).await.unwrap().unwrap();
             println!("CLIENT: The result is '{response:?}'");
             assert_eq!(response, [10, 7777, 8888, 40]);
 

--- a/examples/tls-server.rs
+++ b/examples/tls-server.rs
@@ -271,7 +271,7 @@ async fn client_context(socket_addr: SocketAddr) {
             let mut ctx = tcp::attach(transport);
 
             println!("CLIENT: Reading 2 input registers...");
-            let response = ctx.read_input_registers(0x00, 2).await.unwrap();
+            let response = ctx.read_input_registers(0x00, 2).await.unwrap().unwrap();
             println!("CLIENT: The result is '{response:?}'");
             assert_eq!(response, [1234, 5678]);
 
@@ -282,7 +282,7 @@ async fn client_context(socket_addr: SocketAddr) {
 
             // Read back a block including the two registers we wrote.
             println!("CLIENT: Reading 4 holding registers...");
-            let response = ctx.read_holding_registers(0x00, 4).await.unwrap();
+            let response = ctx.read_holding_registers(0x00, 4).await.unwrap().unwrap();
             println!("CLIENT: The result is '{response:?}'");
             assert_eq!(response, [10, 7777, 8888, 40]);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,9 @@ mod codec;
 mod frame;
 pub use self::frame::{Address, Exception, FunctionCode, Quantity, Request, Response};
 
+/// Specialized [`std::result::Result`] type for `Modbus` operations.
+pub type Result<T> = std::result::Result<T, Exception>;
+
 mod service;
 
 #[cfg(feature = "server")]

--- a/tests/exception/mod.rs
+++ b/tests/exception/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2017-2024 slowtec GmbH <post@slowtec.de>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{borrow::Cow, future};
+use std::future;
 
 use tokio_modbus::{
     client::{Context, Reader, Writer},
@@ -42,125 +42,66 @@ impl Service for TestService {
 
 // TODO: Update the `assert_eq` with a check on Exception once Client trait can return Exception
 pub async fn check_client_context(mut ctx: Context) {
-    let response = ctx.read_coils(0x00, 2).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::ReadCoils(0, 0).function_code(),
-            Exception::Acknowledge
-        ),
-    );
+    let response = ctx.read_coils(0x00, 2).await.expect("communication failed");
+    assert_eq!(response, Err(Exception::Acknowledge));
 
-    let response = ctx.read_discrete_inputs(0x00, 2).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::ReadDiscreteInputs(0, 0).function_code(),
-            Exception::GatewayPathUnavailable
-        ),
-    );
+    let response = ctx
+        .read_discrete_inputs(0x00, 2)
+        .await
+        .expect("communication failed");
+    assert_eq!(response, Err(Exception::GatewayPathUnavailable));
 
-    let response = ctx.write_single_coil(0x00, true).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::WriteSingleCoil(0, true).function_code(),
-            Exception::GatewayTargetDevice
-        ),
-    );
+    let response = ctx
+        .write_single_coil(0x00, true)
+        .await
+        .expect("communication failed");
+    assert_eq!(response, Err(Exception::GatewayTargetDevice));
 
-    let response = ctx.write_multiple_coils(0x00, &[true]).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::WriteMultipleCoils(0, Cow::Owned(vec![true])).function_code(),
-            Exception::IllegalDataAddress
-        ),
-    );
+    let response = ctx
+        .write_multiple_coils(0x00, &[true])
+        .await
+        .expect("communication failed");
+    assert_eq!(response, Err(Exception::IllegalDataAddress));
 
-    let response = ctx.read_input_registers(0x00, 2).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::ReadInputRegisters(0, 2).function_code(),
-            Exception::IllegalDataValue
-        ),
-    );
+    let response = ctx
+        .read_input_registers(0x00, 2)
+        .await
+        .expect("communication failed");
+    assert_eq!(response, Err(Exception::IllegalDataValue));
 
-    let response = ctx.read_holding_registers(0x00, 2).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::ReadHoldingRegisters(0, 2).function_code(),
-            Exception::IllegalFunction
-        ),
-    );
+    let response = ctx
+        .read_holding_registers(0x00, 2)
+        .await
+        .expect("communication failed");
+    assert_eq!(response, Err(Exception::IllegalFunction));
 
-    let response = ctx.write_single_register(0x00, 42).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::WriteSingleRegister(0, 42).function_code(),
-            Exception::MemoryParityError
-        ),
-    );
+    let response = ctx
+        .write_single_register(0x00, 42)
+        .await
+        .expect("communication failed");
+    assert_eq!(response, Err(Exception::MemoryParityError));
 
-    let response = ctx.write_multiple_registers(0x00, &[42]).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::WriteMultipleRegisters(0, Cow::Owned(vec![42])).function_code(),
-            Exception::ServerDeviceBusy
-        ),
-    );
+    let response = ctx
+        .write_multiple_registers(0x00, &[42])
+        .await
+        .expect("communication failed");
+    assert_eq!(response, Err(Exception::ServerDeviceBusy));
 
-    let response = ctx.masked_write_register(0x00, 0, 0).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::MaskWriteRegister(0, 0, 0).function_code(),
-            Exception::ServerDeviceFailure
-        ),
-    );
+    let response = ctx
+        .masked_write_register(0x00, 0, 0)
+        .await
+        .expect("communication failed");
+    assert_eq!(response, Err(Exception::ServerDeviceFailure));
 
-    let response = ctx.read_write_multiple_registers(0x00, 0, 0, &[42]).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::ReadWriteMultipleRegisters(0, 0, 0, Cow::Owned(vec![42])).function_code(),
-            Exception::IllegalFunction
-        ),
-    );
+    let response = ctx
+        .read_write_multiple_registers(0x00, 0, 0, &[42])
+        .await
+        .expect("communication failed");
+    assert_eq!(response, Err(Exception::IllegalFunction));
 
     // TODO: This codes hangs if used with `rtu-over-tcp-server`, need to check why
-    /*let response = ctx.call(Request::Custom(70, Cow::Owned(vec![42]))).await;
-    assert!(response.is_err());
-    assert_eq!(
-        response.unwrap_err().to_string(),
-        format!(
-            "Modbus function {}: {}",
-            Request::Custom(70, Cow::Owned(vec![42])).function_code(),
-            Exception::IllegalFunction
-        ),
-    );*/
+    /*
+    let response = ctx.call(Request::Custom(70, Cow::Owned(vec![42]))).await.expect("communication failed");
+    assert_eq!(response, Err(Exception::IllegalFunction));
+    */
 }


### PR DESCRIPTION
The new `Client` API enables the user to have 2 errors returned when calling a Modbus function.

1. `std::io::Error`: An error occured on the network side.
2. `tokio_modbus::Exception`: An error occured on the Modbus server.