### PR TITLE
Simplify naming of ProtocolError variants

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,7 +28,7 @@ pub enum ProtocolError {
     ///
     /// The result received from the server is included for further analysis and handling.
     #[error("mismatching headers: {message} {result:?}")]
-    MismatchingHeaders {
+    HeaderMismatch {
         message: String,
         result: Result<Response, ExceptionResponse>,
     },
@@ -37,7 +37,7 @@ pub enum ProtocolError {
     ///
     /// The result received from the server is included for further analysis and handling.
     #[error("mismatching function codes: {request} {result:?}")]
-    MismatchingFunctionCodes {
+    FunctionCodeMismatch {
         request: FunctionCode,
         result: Result<Response, ExceptionResponse>,
     },

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -66,7 +66,7 @@ where
 
         // Match headers of request and response.
         if let Err(message) = verify_response_header(&req_hdr, &res_adu.hdr) {
-            return Err(ProtocolError::MismatchingHeaders { message, result }.into());
+            return Err(ProtocolError::HeaderMismatch { message, result }.into());
         }
 
         // Match function codes of request and response.
@@ -75,7 +75,7 @@ where
             Err(ExceptionResponse { function, .. }) => *function,
         };
         if req_function_code != rsp_function_code {
-            return Err(ProtocolError::MismatchingFunctionCodes {
+            return Err(ProtocolError::FunctionCodeMismatch {
                 request: req_function_code,
                 result,
             }

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -89,7 +89,7 @@ where
 
         // Match headers of request and response.
         if let Err(message) = verify_response_header(&req_hdr, &res_adu.hdr) {
-            return Err(ProtocolError::MismatchingHeaders { message, result }.into());
+            return Err(ProtocolError::HeaderMismatch { message, result }.into());
         }
 
         // Match function codes of request and response.
@@ -98,7 +98,7 @@ where
             Err(ExceptionResponse { function, .. }) => *function,
         };
         if req_function_code != rsp_function_code {
-            return Err(ProtocolError::MismatchingFunctionCodes {
+            return Err(ProtocolError::FunctionCodeMismatch {
                 request: req_function_code,
                 result,
             }


### PR DESCRIPTION
Easier to distinguish if they don't start with the same prefix.