### PR TITLE
feat: rename Exception to ExceptionCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@
 
 ## v0.15.0 (Unreleased)
 
-- Added `Exception::new`.
+- Added `Exception::Custom` and `Exception::new`.
 
 ### Breaking Changes
 
 - Added `Exception::Custom`.
 - Removed `TryFrom<u8>` and `#[repr(u8)]` for `Exception`.
+- Renamed `Exception` to `ExceptionCode` to be more consistent with `FunctionCode`.
 
 ## v0.14.1 (2024-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### Breaking Changes
 
-- Added `Exception::Custom`.
 - Removed `TryFrom<u8>` and `#[repr(u8)]` for `Exception`.
 - Renamed `Exception` to `ExceptionCode` to be more consistent with `FunctionCode`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 
 ## v0.15.0 (Unreleased)
 
-- Added `Exception::Custom` and `Exception::new`.
+- Added `Exception::::new`.
 
 ### Breaking Changes
 
+- Added `Exception::Custom`.
 - Removed `TryFrom<u8>` and `#[repr(u8)]` for `Exception`.
 - Renamed `Exception` to `ExceptionCode` to be more consistent with `FunctionCode`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 - Added `Exception::Custom`.
 - Removed `TryFrom<u8>` and `#[repr(u8)]` for `Exception`.
-- Renamed `Exception` to `ExceptionCode` to be more consistent with `FunctionCode`.
+- Renamed `Exception` to `ExceptionCode` to be more consistent with
+  `FunctionCode`.
 
 ## v0.14.1 (2024-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## v0.15.0 (Unreleased)
 
-- Added `Exception::::new`.
+- Added `Exception::new`.
 
 ### Breaking Changes
 

--- a/examples/rtu-server-address.rs
+++ b/examples/rtu-server-address.rs
@@ -12,7 +12,7 @@ struct Service {
 }
 
 impl Service {
-    fn handle(&self, req: SlaveRequest<'_>) -> Result<Option<Response>, Exception> {
+    fn handle(&self, req: SlaveRequest<'_>) -> Result<Option<Response>, ExceptionCode> {
         let SlaveRequest { slave, request } = req;
         if slave != self.slave.into() {
             // Filtering: Ignore requests with mismatching slave IDs.
@@ -24,7 +24,7 @@ impl Service {
                 registers[2] = 0x77;
                 Ok(Some(Response::ReadInputRegisters(registers)))
             }
-            _ => Err(Exception::IllegalFunction),
+            _ => Err(ExceptionCode::IllegalFunction),
         }
     }
 }
@@ -32,7 +32,7 @@ impl Service {
 impl tokio_modbus::server::Service for Service {
     type Request = SlaveRequest<'static>;
     type Response = Option<Response>;
-    type Exception = Exception;
+    type Exception = ExceptionCode;
     type Future = future::Ready<Result<Self::Response, Self::Exception>>;
 
     fn call(&self, req: Self::Request) -> Self::Future {
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("CLIENT: Reading with illegal function... (should return IllegalFunction)");
     let response = ctx.read_holding_registers(0x100, 1).await.unwrap();
     println!("CLIENT: The result is '{response:?}'");
-    assert!(matches!(response, Err(Exception::IllegalFunction)));
+    assert!(matches!(response, Err(ExceptionCode::IllegalFunction)));
 
     println!("CLIENT: Done.");
 

--- a/examples/rtu-server.rs
+++ b/examples/rtu-server.rs
@@ -12,7 +12,7 @@ struct Service;
 impl tokio_modbus::server::Service for Service {
     type Request = SlaveRequest<'static>;
     type Response = Response;
-    type Exception = Exception;
+    type Exception = ExceptionCode;
     type Future = future::Ready<Result<Self::Response, Self::Exception>>;
 
     fn call(&self, req: Self::Request) -> Self::Future {
@@ -23,7 +23,7 @@ impl tokio_modbus::server::Service for Service {
                 future::ready(Ok(Response::ReadInputRegisters(registers)))
             }
             Request::ReadHoldingRegisters(_, _) => {
-                future::ready(Err(Exception::IllegalDataAddress))
+                future::ready(Err(ExceptionCode::IllegalDataAddress))
             }
             _ => unimplemented!(),
         }
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("CLIENT: Reading nonexistent holding register address... (should return IllegalDataAddress)");
     let response = ctx.read_holding_registers(0x100, 1).await.unwrap();
     println!("CLIENT: The result is '{response:?}'");
-    assert!(matches!(response, Err(Exception::IllegalDataAddress)));
+    assert!(matches!(response, Err(ExceptionCode::IllegalDataAddress)));
 
     println!("CLIENT: Done.");
     Ok(())

--- a/examples/tcp-server.rs
+++ b/examples/tcp-server.rs
@@ -29,7 +29,7 @@ struct ExampleService {
 impl tokio_modbus::server::Service for ExampleService {
     type Request = Request<'static>;
     type Response = Response;
-    type Exception = Exception;
+    type Exception = ExceptionCode;
     type Future = future::Ready<Result<Self::Response, Self::Exception>>;
 
     fn call(&self, req: Self::Request) -> Self::Future {
@@ -54,7 +54,7 @@ impl tokio_modbus::server::Service for ExampleService {
             .map(|_| Response::WriteSingleRegister(addr, value)),
             _ => {
                 println!("SERVER: Exception::IllegalFunction - Unimplemented function code in request: {req:?}");
-                Err(Exception::IllegalFunction)
+                Err(ExceptionCode::IllegalFunction)
             }
         };
         future::ready(res)
@@ -84,7 +84,7 @@ fn register_read(
     registers: &HashMap<u16, u16>,
     addr: u16,
     cnt: u16,
-) -> Result<Vec<u16>, Exception> {
+) -> Result<Vec<u16>, ExceptionCode> {
     let mut response_values = vec![0; cnt.into()];
     for i in 0..cnt {
         let reg_addr = addr + i;
@@ -92,7 +92,7 @@ fn register_read(
             response_values[i as usize] = *r;
         } else {
             println!("SERVER: Exception::IllegalDataAddress");
-            return Err(Exception::IllegalDataAddress);
+            return Err(ExceptionCode::IllegalDataAddress);
         }
     }
 
@@ -105,14 +105,14 @@ fn register_write(
     registers: &mut HashMap<u16, u16>,
     addr: u16,
     values: &[u16],
-) -> Result<(), Exception> {
+) -> Result<(), ExceptionCode> {
     for (i, value) in values.iter().enumerate() {
         let reg_addr = addr + i as u16;
         if let Some(r) = registers.get_mut(&reg_addr) {
             *r = *value;
         } else {
             println!("SERVER: Exception::IllegalDataAddress");
-            return Err(Exception::IllegalDataAddress);
+            return Err(ExceptionCode::IllegalDataAddress);
         }
     }
 
@@ -178,7 +178,7 @@ async fn client_context(socket_addr: SocketAddr) {
             println!("CLIENT: Reading nonexistent holding register address... (should return IllegalDataAddress)");
             let response = ctx.read_holding_registers(0x100, 1).await.unwrap();
             println!("CLIENT: The result is '{response:?}'");
-            assert!(matches!(response, Err(Exception::IllegalDataAddress)));
+            assert!(matches!(response, Err(ExceptionCode::IllegalDataAddress)));
 
             println!("CLIENT: Done.")
         },

--- a/examples/tls-server.rs
+++ b/examples/tls-server.rs
@@ -91,7 +91,7 @@ struct ExampleService {
 impl tokio_modbus::server::Service for ExampleService {
     type Request = Request<'static>;
     type Response = Response;
-    type Exception = Exception;
+    type Exception = ExceptionCode;
     type Future = future::Ready<Result<Self::Response, Self::Exception>>;
 
     fn call(&self, req: Self::Request) -> Self::Future {
@@ -116,7 +116,7 @@ impl tokio_modbus::server::Service for ExampleService {
             .map(|_| Response::WriteSingleRegister(addr, value)),
             _ => {
                 println!("SERVER: Exception::IllegalFunction - Unimplemented function code in request: {req:?}");
-                Err(Exception::IllegalFunction)
+                Err(ExceptionCode::IllegalFunction)
             }
         };
         future::ready(res)
@@ -146,7 +146,7 @@ fn register_read(
     registers: &HashMap<u16, u16>,
     addr: u16,
     cnt: u16,
-) -> Result<Vec<u16>, Exception> {
+) -> Result<Vec<u16>, ExceptionCode> {
     let mut response_values = vec![0; cnt.into()];
     for i in 0..cnt {
         let reg_addr = addr + i;
@@ -154,7 +154,7 @@ fn register_read(
             response_values[i as usize] = *r;
         } else {
             println!("SERVER: Exception::IllegalDataAddress");
-            return Err(Exception::IllegalDataAddress);
+            return Err(ExceptionCode::IllegalDataAddress);
         }
     }
 
@@ -167,14 +167,14 @@ fn register_write(
     registers: &mut HashMap<u16, u16>,
     addr: u16,
     values: &[u16],
-) -> Result<(), Exception> {
+) -> Result<(), ExceptionCode> {
     for (i, value) in values.iter().enumerate() {
         let reg_addr = addr + i as u16;
         if let Some(r) = registers.get_mut(&reg_addr) {
             *r = *value;
         } else {
             println!("SERVER: Exception::IllegalDataAddress");
-            return Err(Exception::IllegalDataAddress);
+            return Err(ExceptionCode::IllegalDataAddress);
         }
     }
 
@@ -287,7 +287,7 @@ async fn client_context(socket_addr: SocketAddr) {
             println!("CLIENT: Reading nonexistent holding register address... (should return IllegalDataAddress)");
             let response = ctx.read_holding_registers(0x100, 1).await.unwrap();
             println!("CLIENT: The result is '{response:?}'");
-            assert!(matches!(response, Err(Exception::IllegalDataAddress)));
+            assert!(matches!(response, Err(ExceptionCode::IllegalDataAddress)));
 
             println!("CLIENT: Done.")
         },

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -385,7 +385,7 @@ impl TryFrom<Bytes> for ExceptionResponse {
             ));
         }
         let function = fn_err_code - 0x80;
-        let exception = Exception::new(rdr.read_u8()?);
+        let exception = ExceptionCode::new(rdr.read_u8()?);
         Ok(ExceptionResponse {
             function: FunctionCode::new(function),
             exception,
@@ -529,7 +529,7 @@ mod tests {
     fn exception_response_into_bytes() {
         let bytes: Bytes = ExceptionResponse {
             function: FunctionCode::ReadHoldingRegisters,
-            exception: Exception::IllegalDataAddress,
+            exception: ExceptionCode::IllegalDataAddress,
         }
         .into();
         assert_eq!(bytes[0], 0x83);
@@ -546,7 +546,7 @@ mod tests {
             rsp,
             ExceptionResponse {
                 function: FunctionCode::ReadHoldingRegisters,
-                exception: Exception::IllegalDataAddress,
+                exception: ExceptionCode::IllegalDataAddress,
             }
         );
     }
@@ -557,7 +557,7 @@ mod tests {
         let rsp_pdu: Bytes = Response::ReadCoils(vec![]).into();
         let ex_pdu: Bytes = ExceptionResponse {
             function: FunctionCode::ReadHoldingRegisters,
-            exception: Exception::ServerDeviceFailure,
+            exception: ExceptionCode::ServerDeviceFailure,
         }
         .into();
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -387,7 +387,7 @@ impl Response {
 
 /// A server (slave) exception.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Exception {
+pub enum ExceptionCode {
     /// 0x01
     IllegalFunction,
     /// 0x02
@@ -413,9 +413,9 @@ pub enum Exception {
     Custom(u8),
 }
 
-impl From<Exception> for u8 {
-    fn from(from: Exception) -> Self {
-        use crate::frame::Exception::*;
+impl From<ExceptionCode> for u8 {
+    fn from(from: ExceptionCode) -> Self {
+        use crate::frame::ExceptionCode::*;
         match from {
             IllegalFunction => 0x01,
             IllegalDataAddress => 0x02,
@@ -431,11 +431,11 @@ impl From<Exception> for u8 {
     }
 }
 
-impl Exception {
-    /// Create a new [`Exception`] with `value`.
+impl ExceptionCode {
+    /// Create a new [`ExceptionCode`] with `value`.
     #[must_use]
     pub const fn new(value: u8) -> Self {
-        use crate::frame::Exception::*;
+        use crate::frame::ExceptionCode::*;
 
         match value {
             0x01 => IllegalFunction,
@@ -452,7 +452,7 @@ impl Exception {
     }
 
     pub(crate) fn description(&self) -> &str {
-        use crate::frame::Exception::*;
+        use crate::frame::ExceptionCode::*;
 
         match *self {
             IllegalFunction => "Illegal function",
@@ -473,7 +473,7 @@ impl Exception {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExceptionResponse {
     pub function: FunctionCode,
-    pub exception: Exception,
+    pub exception: ExceptionCode,
 }
 
 /// Represents a message from the client (slave) to the server (master).
@@ -537,13 +537,13 @@ impl From<ResponsePdu> for Result<Response, ExceptionResponse> {
     }
 }
 
-impl fmt::Display for Exception {
+impl fmt::Display for ExceptionCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description())
     }
 }
 
-impl error::Error for Exception {
+impl error::Error for ExceptionCode {
     fn description(&self) -> &str {
         self.description()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ mod frame;
 #[cfg(feature = "server")]
 pub use self::frame::SlaveRequest;
 pub use self::frame::{
-    Address, Exception, ExceptionResponse, FunctionCode, Quantity, Request, Response,
+    Address, ExceptionCode, ExceptionResponse, FunctionCode, Quantity, Request, Response,
 };
 
 /// Specialized [`std::result::Result`] type for type-checked responses of the _Modbus_ client API.
@@ -58,8 +58,8 @@ pub use self::frame::{
 /// This [`Result`] type contains 2 layers of errors.
 ///
 /// 1. [`Error`]: An unexpected protocol or network error that occurred during client/server communication.
-/// 2. [`Exception`]: An error occurred on the _Modbus_ server.
-pub type Result<T> = std::result::Result<std::result::Result<T, Exception>, Error>;
+/// 2. [`ExceptionCode`]: An error occurred on the _Modbus_ server.
+pub type Result<T> = std::result::Result<std::result::Result<T, ExceptionCode>, Error>;
 
 mod service;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,7 +29,7 @@ pub mod sync {
 ///////////////////////////////////////////////////////////////////
 /// Types
 ///////////////////////////////////////////////////////////////////
-pub use crate::{Exception, ProtocolError, Request, Response, Slave, SlaveId};
+pub use crate::{ExceptionCode, ProtocolError, Request, Response, Slave, SlaveId};
 
 #[cfg(feature = "server")]
 pub use crate::frame::SlaveRequest;

--- a/src/server/rtu_over_tcp.rs
+++ b/src/server/rtu_over_tcp.rs
@@ -221,7 +221,7 @@ mod tests {
         impl Service for DummyService {
             type Request = Request<'static>;
             type Response = Response;
-            type Exception = Exception;
+            type Exception = ExceptionCode;
             type Future = future::Ready<Result<Self::Response, Self::Exception>>;
 
             fn call(&self, _: Self::Request) -> Self::Future {
@@ -256,7 +256,7 @@ mod tests {
         impl Service for DummyService {
             type Request = Request<'static>;
             type Response = Response;
-            type Exception = Exception;
+            type Exception = ExceptionCode;
             type Future = future::Ready<Result<Self::Response, Self::Exception>>;
 
             fn call(&self, _: Self::Request) -> Self::Future {

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -22,8 +22,8 @@ pub trait Service {
 
     /// Exceptional responses sent by the service.
     ///
-    /// Use [`tokio_modbus::Exception`](crate::Exception) as default.
-    type Exception: Into<crate::Exception>;
+    /// Use [`tokio_modbus::ExceptionCode`](crate::ExceptionCode) as default.
+    type Exception: Into<crate::ExceptionCode>;
 
     /// The future response value.
     type Future: Future<Output = Result<Self::Response, Self::Exception>> + Send;

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -218,7 +218,7 @@ mod tests {
         impl Service for DummyService {
             type Request = Request<'static>;
             type Response = Response;
-            type Exception = Exception;
+            type Exception = ExceptionCode;
             type Future = future::Ready<Result<Self::Response, Self::Exception>>;
 
             fn call(&self, _: Self::Request) -> Self::Future {
@@ -253,8 +253,8 @@ mod tests {
         impl Service for DummyService {
             type Request = Request<'static>;
             type Response = Response;
-            type Exception = Exception;
-            type Future = future::Ready<Result<Self::Response, Exception>>;
+            type Exception = ExceptionCode;
+            type Future = future::Ready<Result<Self::Response, ExceptionCode>>;
 
             fn call(&self, _: Self::Request) -> Self::Future {
                 future::ready(Ok(self.response.clone()))

--- a/tests/exception/mod.rs
+++ b/tests/exception/mod.rs
@@ -6,26 +6,26 @@ use std::future;
 use tokio_modbus::{
     client::{Context, Reader as _, Writer as _},
     server::Service,
-    Exception, Request, Response,
+    ExceptionCode, Request, Response,
 };
 
 pub struct TestService {}
 
 impl TestService {
-    fn handle(&self, req: Request<'static>) -> Result<Response, Exception> {
+    fn handle(&self, req: Request<'static>) -> Result<Response, ExceptionCode> {
         use Request::*;
 
         match req {
-            ReadCoils(_, _) => Err(Exception::Acknowledge),
-            ReadDiscreteInputs(_, _) => Err(Exception::GatewayPathUnavailable),
-            WriteSingleCoil(_, _) => Err(Exception::GatewayTargetDevice),
-            WriteMultipleCoils(_, _) => Err(Exception::IllegalDataAddress),
-            ReadInputRegisters(_, _) => Err(Exception::IllegalDataValue),
-            ReadHoldingRegisters(_, _) => Err(Exception::IllegalFunction),
-            WriteSingleRegister(_, _) => Err(Exception::MemoryParityError),
-            WriteMultipleRegisters(_, _) => Err(Exception::ServerDeviceBusy),
-            MaskWriteRegister(_, _, _) => Err(Exception::ServerDeviceFailure),
-            _ => Err(Exception::IllegalFunction),
+            ReadCoils(_, _) => Err(ExceptionCode::Acknowledge),
+            ReadDiscreteInputs(_, _) => Err(ExceptionCode::GatewayPathUnavailable),
+            WriteSingleCoil(_, _) => Err(ExceptionCode::GatewayTargetDevice),
+            WriteMultipleCoils(_, _) => Err(ExceptionCode::IllegalDataAddress),
+            ReadInputRegisters(_, _) => Err(ExceptionCode::IllegalDataValue),
+            ReadHoldingRegisters(_, _) => Err(ExceptionCode::IllegalFunction),
+            WriteSingleRegister(_, _) => Err(ExceptionCode::MemoryParityError),
+            WriteMultipleRegisters(_, _) => Err(ExceptionCode::ServerDeviceBusy),
+            MaskWriteRegister(_, _, _) => Err(ExceptionCode::ServerDeviceFailure),
+            _ => Err(ExceptionCode::IllegalFunction),
         }
     }
 }
@@ -35,7 +35,7 @@ impl Service for TestService {
 
     type Response = Response;
 
-    type Exception = Exception;
+    type Exception = ExceptionCode;
 
     type Future = future::Ready<Result<Self::Response, Self::Exception>>;
 
@@ -47,61 +47,64 @@ impl Service for TestService {
 // TODO: Update the `assert_eq` with a check on Exception once Client trait can return Exception
 pub async fn check_client_context(mut ctx: Context) {
     let response = ctx.read_coils(0x00, 2).await.unwrap();
-    assert!(matches!(response, Err(Exception::Acknowledge)));
+    assert!(matches!(response, Err(ExceptionCode::Acknowledge)));
 
     let response = ctx
         .read_discrete_inputs(0x00, 2)
         .await
         .expect("communication failed");
-    assert!(matches!(response, Err(Exception::GatewayPathUnavailable)));
+    assert!(matches!(
+        response,
+        Err(ExceptionCode::GatewayPathUnavailable)
+    ));
 
     let response = ctx
         .write_single_coil(0x00, true)
         .await
         .expect("communication failed");
-    assert!(matches!(response, Err(Exception::GatewayTargetDevice)));
+    assert!(matches!(response, Err(ExceptionCode::GatewayTargetDevice)));
 
     let response = ctx
         .write_multiple_coils(0x00, &[true])
         .await
         .expect("communication failed");
-    assert!(matches!(response, Err(Exception::IllegalDataAddress)));
+    assert!(matches!(response, Err(ExceptionCode::IllegalDataAddress)));
 
     let response = ctx
         .read_input_registers(0x00, 2)
         .await
         .expect("communication failed");
-    assert!(matches!(response, Err(Exception::IllegalDataValue)));
+    assert!(matches!(response, Err(ExceptionCode::IllegalDataValue)));
 
     let response = ctx
         .read_holding_registers(0x00, 2)
         .await
         .expect("communication failed");
-    assert!(matches!(response, Err(Exception::IllegalFunction)));
+    assert!(matches!(response, Err(ExceptionCode::IllegalFunction)));
 
     let response = ctx
         .write_single_register(0x00, 42)
         .await
         .expect("communication failed");
-    assert!(matches!(response, Err(Exception::MemoryParityError)));
+    assert!(matches!(response, Err(ExceptionCode::MemoryParityError)));
 
     let response = ctx
         .write_multiple_registers(0x00, &[42])
         .await
         .expect("communication failed");
-    assert!(matches!(response, Err(Exception::ServerDeviceBusy)));
+    assert!(matches!(response, Err(ExceptionCode::ServerDeviceBusy)));
 
     let response = ctx
         .masked_write_register(0x00, 0, 0)
         .await
         .expect("communication failed");
-    assert!(matches!(response, Err(Exception::ServerDeviceFailure)));
+    assert!(matches!(response, Err(ExceptionCode::ServerDeviceFailure)));
 
     let response = ctx
         .read_write_multiple_registers(0x00, 0, 0, &[42])
         .await
         .expect("communication failed");
-    assert!(matches!(response, Err(Exception::IllegalFunction)));
+    assert!(matches!(response, Err(ExceptionCode::IllegalFunction)));
 
     // TODO: This codes hangs if used with `rtu-over-tcp-server`, need to check why
     // let response = ctx


### PR DESCRIPTION
In #279 @uklotzde mentioned that:
> I have noticed that the naming of the types FunctionCode and Exception is inconsistent. Shouldn't Exception better be renamed to ExceptionCode to reflect this duality?

This PR does exactly this, renames `Exception` to `ExceptionCode`.

Also, should associated types be renamed? This is an example:
https://github.com/slowtec/tokio-modbus/blob/a5eb819dd30e21e43c46f0af8c64fbbab2a2e619/src/server/rtu_over_tcp.rs#L224
To become:
```rust
type ExceptionCode = ExceptionCode
```