### PR TITLE
Remove unnecessary Debug trait requirement

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,7 +3,7 @@
 
 //! Modbus clients
 
-use std::{borrow::Cow, fmt::Debug, io};
+use std::{borrow::Cow, io};
 
 use async_trait::async_trait;
 
@@ -20,7 +20,7 @@ pub mod sync;
 
 /// Transport independent asynchronous client trait
 #[async_trait]
-pub trait Client: SlaveContext + Send + Debug {
+pub trait Client: SlaveContext + Send {
     /// Invokes a _Modbus_ function.
     async fn call(&mut self, request: Request<'_>) -> Result<Response>;
 
@@ -89,7 +89,7 @@ pub trait Writer: Client {
 }
 
 /// Asynchronous Modbus client context
-#[derive(Debug)]
+#[allow(missing_debug_implementations)]
 pub struct Context {
     client: Box<dyn Client>,
 }

--- a/src/client/rtu.rs
+++ b/src/client/rtu.rs
@@ -11,7 +11,7 @@ use super::*;
 /// broadcast messages.
 pub fn attach<T>(transport: T) -> Context
 where
-    T: AsyncRead + AsyncWrite + Debug + Unpin + Send + 'static,
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     attach_slave(transport, Slave::broadcast())
 }
@@ -19,7 +19,7 @@ where
 /// Connect to any kind of Modbus slave device.
 pub fn attach_slave<T>(transport: T, slave: Slave) -> Context
 where
-    T: AsyncRead + AsyncWrite + Debug + Unpin + Send + 'static,
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let client = crate::service::rtu::Client::new(transport, slave);
     Context {

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2017-2024 slowtec GmbH <post@slowtec.de>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{fmt, io};
+use std::io;
 
 use futures_util::{SinkExt as _, StreamExt as _};
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -119,7 +119,7 @@ impl<T> SlaveContext for Client<T> {
 #[async_trait::async_trait]
 impl<T> crate::client::Client for Client<T>
 where
-    T: fmt::Debug + AsyncRead + AsyncWrite + Send + Unpin,
+    T: AsyncRead + AsyncWrite + Send + Unpin,
 {
     async fn call(&mut self, req: Request<'_>) -> Result<Response> {
         self.call(req).await

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2017-2024 slowtec GmbH <post@slowtec.de>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{fmt, io};
+use std::io;
 
 use futures_util::{SinkExt as _, StreamExt as _};
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -152,7 +152,7 @@ impl<T> SlaveContext for Client<T> {
 #[async_trait::async_trait]
 impl<T> crate::client::Client for Client<T>
 where
-    T: fmt::Debug + AsyncRead + AsyncWrite + Send + Unpin,
+    T: AsyncRead + AsyncWrite + Send + Unpin,
 {
     async fn call(&mut self, req: Request<'_>) -> Result<Response> {
         self.call(req).await


### PR DESCRIPTION
The Debug trait was an unnecessary requirement on the abstract transport layer and is unused internally.
Removing it simplifies the code without impacting functionality.