### PR TITLE
deps: update socket2 to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ futures-core = { version = "0.3.30", optional = true, default-features = false }
 futures-util = { version = "0.3.30", optional = true, default-features = false }
 log = "0.4.20"
 smallvec = { version = "1.13.1", optional = true, default-features = false }
-socket2 = { version = "0.5.5", optional = true, default-features = false }
+socket2 = { version = "0.6.0", optional = true, default-features = false }
 thiserror = "2.0.3"
 tokio = { version = "1.35.1", default-features = false, features = ["io-util"] }
 # Disable default-features to exclude unused dependency on libudev


### PR DESCRIPTION
Fortunately no breaking changes for the project, libs are starting to migrate to it so I'd say to update it.