### PR TITLE
Disconnect client sockets when TCP/RTU over TCP server exits (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 # Changelog
 
+## Unreleased
+
+- Fix: TCP and RTU over TCP servers now disconnect client sockets when serve exits
+
 ## v0.16.1 (2024-12-12)
 
 - Decoding of requests/responses: Disable max. PDU size checks for custom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ## Unreleased
 
-- Fix: TCP and RTU over TCP servers now disconnect client sockets when serve exits
+- Fix: TCP and RTU over TCP servers now disconnect client sockets when serve
+  exits
 
 ## v0.16.1 (2024-12-12)
 

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -12,7 +12,7 @@ use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::{TcpListener, TcpStream},
 };
-use tokio_util::codec::Framed;
+use tokio_util::{codec::Framed, sync::CancellationToken};
 
 use crate::{
     codec::tcp::ServerCodec,
@@ -79,6 +79,9 @@ impl Server {
         F: Future<Output = io::Result<Option<(S, T)>>>,
         OnProcessError: FnOnce(io::Error) + Clone + Send + 'static,
     {
+        let cancel = CancellationToken::new();
+        let _guard = cancel.drop_guard_ref();
+
         loop {
             let (stream, socket_addr) = self.listener.accept().await?;
             log::debug!("Accepted connection from {socket_addr}");
@@ -90,10 +93,11 @@ impl Server {
             let on_process_error = on_process_error.clone();
 
             let framed = Framed::new(transport, ServerCodec::default());
+            let cancel = cancel.clone();
 
             tokio::spawn(async move {
                 log::debug!("Processing requests from {socket_addr}");
-                if let Err(err) = process(framed, service).await {
+                if let Some(Err(err)) = cancel.run_until_cancelled(process(framed, service)).await {
                     on_process_error(err);
                 }
             });

--- a/tests/rtu_over_tcp_server_shutdown.rs
+++ b/tests/rtu_over_tcp_server_shutdown.rs
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2017-2025 slowtec GmbH <post@slowtec.de>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Test to demonstrate that RTU over TCP server properly disconnects clients when cancelled.
+//! Test for [#329 Cancelling or otherwise shutting down the TCP server does not disconnect clients](https://github.com/slowtec/tokio-modbus/issues/329).
+//! Test for [#333 serve_until is not handing current existing clients](https://github.com/slowtec/tokio-modbus/issues/333).
+
+#![cfg(feature = "rtu-over-tcp-server")]
+
+#[allow(unused)]
+mod exception;
+
+use std::{net::SocketAddr, time::Duration};
+
+use futures::future::FutureExt;
+use tokio::{
+    net::TcpListener,
+    sync::oneshot::{channel, Receiver, Sender},
+};
+use tokio_modbus::{
+    prelude::*,
+    server::rtu_over_tcp::{accept_tcp_connection, Server},
+    server::Terminated,
+};
+
+use crate::exception::TestService;
+
+#[tokio::test]
+async fn test_server_shutdown_disconnects_clients() {
+    let socket_addr = "127.0.0.1:5502".parse().unwrap();
+    let (sender, receiver) = channel();
+    let server_task = tokio::spawn(server_context(socket_addr, receiver));
+    let client_task = tokio::spawn(client_context(socket_addr, sender));
+    assert!(matches!(
+        server_task.await.unwrap(),
+        Ok(Terminated::Aborted)
+    ));
+    client_task.await.unwrap();
+}
+
+async fn server_context(
+    socket_addr: SocketAddr,
+    receiver: Receiver<()>,
+) -> std::io::Result<Terminated> {
+    println!("Starting up server on {socket_addr}");
+    let listener = TcpListener::bind(socket_addr).await?;
+    let server = Server::new(listener);
+    let new_service = |_socket_addr| Ok(Some(TestService {}));
+    let on_connected = |stream, socket_addr| async move {
+        accept_tcp_connection(stream, socket_addr, new_service)
+    };
+    let on_process_error = |err| {
+        eprintln!("{err}");
+    };
+    let abort_signal = receiver.map(|_| ());
+    server
+        .serve_until(&on_connected, on_process_error, abort_signal)
+        .await
+}
+
+async fn client_context(socket_addr: SocketAddr, sender: Sender<()>) {
+    // Give the server some time for starting up
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Connect to server
+    let transport = tokio::net::TcpStream::connect(socket_addr).await.unwrap();
+    let mut ctx = tokio_modbus::prelude::rtu::attach_slave(transport, Slave(1));
+    // Check that a request receives a response
+    assert!(ctx.read_input_registers(0, 1).await.is_ok());
+    // Stop the server
+    sender.send(()).unwrap();
+    // Give the server some time for winding down
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Check that a request does not receive a response
+    assert!(ctx.read_input_registers(0, 1).await.is_err());
+}

--- a/tests/tcp_server_shutdown.rs
+++ b/tests/tcp_server_shutdown.rs
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2017-2025 slowtec GmbH <post@slowtec.de>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Test to demonstrate that TCP server properly disconnects clients when cancelled.
+//! Test for [#329 Cancelling or otherwise shutting down the TCP server does not disconnect clients](https://github.com/slowtec/tokio-modbus/issues/329).
+//! Test for [#333 serve_until is not handing current existing clients](https://github.com/slowtec/tokio-modbus/issues/333).
+
+#![cfg(feature = "tcp-server")]
+
+#[allow(unused)]
+mod exception;
+
+use std::{net::SocketAddr, time::Duration};
+
+use futures::future::FutureExt;
+use tokio::{
+    net::TcpListener,
+    sync::oneshot::{channel, Receiver, Sender},
+};
+use tokio_modbus::{
+    client,
+    prelude::*,
+    server::tcp::{accept_tcp_connection, Server},
+    server::Terminated,
+};
+
+use crate::exception::TestService;
+
+#[tokio::test]
+async fn test_server_shutdown_disconnects_clients() {
+    let socket_addr = "127.0.0.1:5502".parse().unwrap();
+    let (sender, receiver) = channel();
+    let server_task = tokio::spawn(server_context(socket_addr, receiver));
+    let client_task = tokio::spawn(client_context(socket_addr, sender));
+    assert!(matches!(
+        server_task.await.unwrap(),
+        Ok(Terminated::Aborted)
+    ));
+    client_task.await.unwrap();
+}
+
+async fn server_context(
+    socket_addr: SocketAddr,
+    receiver: Receiver<()>,
+) -> std::io::Result<Terminated> {
+    println!("Starting up server on {socket_addr}");
+    let listener = TcpListener::bind(socket_addr).await?;
+    let server = Server::new(listener);
+    let new_service = |_socket_addr| Ok(Some(TestService {}));
+    let on_connected = |stream, socket_addr| async move {
+        accept_tcp_connection(stream, socket_addr, new_service)
+    };
+    let on_process_error = |err| {
+        eprintln!("{err}");
+    };
+    let abort_signal = receiver.map(|_| ());
+    server
+        .serve_until(&on_connected, on_process_error, abort_signal)
+        .await
+}
+
+async fn client_context(socket_addr: SocketAddr, sender: Sender<()>) {
+    // Give the server some time for starting up
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Connect to server
+    let mut ctx = client::tcp::connect(socket_addr).await.unwrap();
+    // Check that a request receives a response
+    assert!(ctx.read_input_registers(0, 1).await.is_ok());
+    // Stop the server
+    sender.send(()).unwrap();
+    // Give the server some time for winding down
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Check that a request does not receive a response
+    assert!(ctx.read_input_registers(0, 1).await.is_err());
+}


### PR DESCRIPTION
I have recently been having problems related to issues #329 and #333 also.  This pull request is a proposed solution that is a slightly more minimal change than the one in #334.