### PR TITLE
Update minimum required version of tokio-util (#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## Unreleased
 
+- Fix: Previous fix uses a feature from a newer version of tokio-util than the
+  version specified in Cargo.toml
+
 ## v0.16.2 (2025-09-09)
 
 - Fix: TCP and RTU over TCP servers now disconnect client sockets when serve

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "2.0.3"
 tokio = { version = "1.35.1", default-features = false, features = ["io-util"] }
 # Disable default-features to exclude unused dependency on libudev
 tokio-serial = { version = "5.4.4", optional = true, default-features = false }
-tokio-util = { version = "0.7.10", optional = true, default-features = false, features = ["codec"] }
+tokio-util = { version = "0.7.16", optional = true, default-features = false, features = ["codec"] }
 
 [dev-dependencies]
 anyhow = "1.0.86"


### PR DESCRIPTION
Required due to the usage of `DropGuardRef` in #336.