### PR TITLE
server: Remove unneeded `Unpin` trait bounds for abort signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## Unreleased
 
+- Server: Remove unneeded `Unpin` trait bounds for abort signal.
+
 ## v0.16.4 (2025-09-17)
 
 - Added `ReadDeviceIdentification`

--- a/src/server/rtu.rs
+++ b/src/server/rtu.rs
@@ -56,7 +56,7 @@ impl Server {
     where
         S: Service + Send + Sync + 'static,
         S::Request: From<RequestAdu<'static>> + Send,
-        X: Future<Output = ()> + Sync + Send + Unpin + 'static,
+        X: Future<Output = ()> + Sync + Send + 'static,
     {
         let framed = Framed::new(self.serial, ServerCodec::default());
         let abort_signal = abort_signal.fuse();

--- a/src/server/rtu_over_tcp.rs
+++ b/src/server/rtu_over_tcp.rs
@@ -119,7 +119,7 @@ impl Server {
         S: Service + Send + Sync + 'static,
         S::Request: From<RequestAdu<'static>> + Send,
         T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-        X: Future<Output = ()> + Sync + Send + Unpin + 'static,
+        X: Future<Output = ()> + Sync + Send + 'static,
         OnConnected: Fn(TcpStream, SocketAddr) -> F,
         F: Future<Output = io::Result<Option<(S, T)>>>,
         OnProcessError: FnOnce(io::Error) + Clone + Send + 'static,

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -118,7 +118,7 @@ impl Server {
         S: Service + Send + Sync + 'static,
         S::Request: From<RequestAdu<'static>> + Send,
         T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-        X: Future<Output = ()> + Sync + Send + Unpin + 'static,
+        X: Future<Output = ()> + Sync + Send + 'static,
         OnConnected: Fn(TcpStream, SocketAddr) -> F,
         F: Future<Output = io::Result<Option<(S, T)>>>,
         OnProcessError: FnOnce(io::Error) + Clone + Send + 'static,


### PR DESCRIPTION
Closes #337.