### PR TITLE
refactor(server): replace transpose with match for request error hand…

### DIFF
--- a/src/server/rtu.rs
+++ b/src/server/rtu.rs
@@ -78,12 +78,16 @@ where
     S::Request: From<RequestAdu<'static>> + Send,
 {
     loop {
-        let Some(request_adu) = framed.next().await.transpose().inspect_err(|err| {
-            log::debug!("Failed to receive and decode request ADU: {err}");
-        })?
-        else {
-            log::debug!("Stream has finished");
-            break;
+        let request_adu = match framed.next().await {
+            Some(Ok(adu)) => adu,
+            Some(Err(err)) => {
+                log::debug!("Failed to receive and decode request ADU: {err}");
+                continue;
+            }
+            None => {
+                log::debug!("TCP socket has been closed");
+                break;
+            }
         };
 
         let RequestAdu {

--- a/src/server/rtu_over_tcp.rs
+++ b/src/server/rtu_over_tcp.rs
@@ -144,12 +144,16 @@ where
     T: AsyncRead + AsyncWrite + Unpin,
 {
     loop {
-        let Some(request_adu) = framed.next().await.transpose().inspect_err(|err| {
-            log::debug!("Failed to receive and decode request ADU: {err}");
-        })?
-        else {
-            log::debug!("TCP socket has been closed");
-            break;
+        let request_adu = match framed.next().await {
+            Some(Ok(adu)) => adu,
+            Some(Err(err)) => {
+                log::debug!("Failed to receive and decode request ADU: {err}");
+                continue;
+            }
+            None => {
+                log::debug!("TCP socket has been closed");
+                break;
+            }
         };
 
         let RequestAdu {

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -143,12 +143,16 @@ where
     T: AsyncRead + AsyncWrite + Unpin,
 {
     loop {
-        let Some(request_adu) = framed.next().await.transpose().inspect_err(|err| {
-            log::debug!("Failed to receive and decode request ADU: {err}");
-        })?
-        else {
-            log::debug!("TCP socket has been closed");
-            break;
+        let request_adu = match framed.next().await {
+            Some(Ok(adu)) => adu,
+            Some(Err(err)) => {
+                log::debug!("Failed to receive and decode request ADU: {err}");
+                continue;
+            }
+            None => {
+                log::debug!("TCP socket has been closed");
+                break;
+            }
         };
 
         let RequestAdu {


### PR DESCRIPTION
…ling

Refactor request processing logic in tcp, rtu, and rtu_over_tcp modules to use explicit match expressions instead of transpose. Improve error handling clarity by continuing the loop on error instead of returning immediately.