### PR TITLE
Use explicit error message instead of syscall for unexpected TCP connection drops

### DIFF
--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -100,7 +100,12 @@ where
         framed.read_buffer_mut().clear();
         framed.send(req_adu).await?;
 
-        let res_adu = framed.next().await.ok_or_else(io::Error::last_os_error)??;
+        let res_adu = framed
+            .next()
+            .await
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::UnexpectedEof, "connection closed by remote")
+            })??;
         let ResponseAdu {
             hdr: res_hdr,
             pdu: res_pdu,


### PR DESCRIPTION
The use of `io::Error::last_os_error` [can result is confusing error messages](https://doc.rust-lang.org/std/io/struct.Error.html#method.last_os_error) such as an indication that operation completed successfully. So, I've replaced the `io::Error::last_os_error` call with an explicit `UnexpectedEof` error. I believe the only case where we should get an error from the `next()` call is if we have a premature connection closure.

This is a fix for https://github.com/slowtec/tokio-modbus/issues/325.