### PR TITLE
Implement RTU Broadcast

### DIFF
--- a/examples/rtu-client-sync.rs
+++ b/examples/rtu-client-sync.rs
@@ -6,7 +6,10 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use tokio_modbus::prelude::*;
 
-    let tty_path = "/dev/ttyUSB0";
+    let tty_path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/dev/ttyUSB0".into());
+
     let slave = Slave(0x17);
 
     let builder = tokio_serial::new(tty_path, 19200);

--- a/examples/rtu-client.rs
+++ b/examples/rtu-client.rs
@@ -9,7 +9,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     use tokio_modbus::prelude::*;
 
-    let tty_path = "/dev/ttyUSB0";
+    let tty_path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/dev/ttyUSB0".into());
+
     let slave = Slave(0x17);
 
     let builder = tokio_serial::new(tty_path, 19200);
@@ -19,6 +22,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Reading a sensor value");
     let rsp = ctx.read_holding_registers(0x082B, 2).await??;
     println!("Sensor value is: {rsp:?}");
+
+    println!("Broadcasting a single coil write to all devices");
+    ctx.set_slave(Slave::broadcast());
+    ctx.write_single_coil(0x00, true).await??;
 
     println!("Disconnecting");
     ctx.disconnect().await?;

--- a/examples/rtu-server-address.rs
+++ b/examples/rtu-server-address.rs
@@ -43,7 +43,10 @@ impl tokio_modbus::server::Service for Service {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let slave = Slave(12);
-    let builder = tokio_serial::new("/dev/ttyS10", 19200);
+    let tty_path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/dev/ttyS10".into());
+    let builder = tokio_serial::new(&tty_path, 19200);
     let server_serial = tokio_serial::SerialStream::open(&builder).unwrap();
 
     println!("Starting up server...");

--- a/examples/tcp-client-custom-fn.rs
+++ b/examples/tcp-client-custom-fn.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rsp = ctx
         .call(Request::Custom(0x66, Cow::Borrowed(&[0x11, 0x42])))
         .await??
-        .expect("response expected for non-broadcast request");
+        .expect("response expected");
 
     match rsp {
         Response::Custom(f, rsp) => {

--- a/examples/tcp-client-custom-fn.rs
+++ b/examples/tcp-client-custom-fn.rs
@@ -16,7 +16,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Fetching the coupler ID");
     let rsp = ctx
         .call(Request::Custom(0x66, Cow::Borrowed(&[0x11, 0x42])))
-        .await??;
+        .await??
+        .expect("response expected for non-broadcast request");
 
     match rsp {
         Response::Custom(f, rsp) => {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -22,7 +22,10 @@ pub mod sync;
 #[async_trait]
 pub trait Client: SlaveContext + Send {
     /// Invokes a _Modbus_ function.
-    async fn call(&mut self, request: Request<'_>) -> Result<Response>;
+    ///
+    /// For broadcast requests (slave ID 0), the request is sent but
+    /// no response is awaited, and `Ok(Ok(None))` is returned.
+    async fn call(&mut self, request: Request<'_>) -> Result<Option<Response>>;
 
     /// Disconnects the client.
     ///
@@ -130,7 +133,7 @@ impl From<Context> for Box<dyn Client> {
 
 #[async_trait]
 impl Client for Context {
-    async fn call(&mut self, request: Request<'_>) -> Result<Response> {
+    async fn call(&mut self, request: Request<'_>) -> Result<Option<Response>> {
         self.client.call(request).await
     }
 
@@ -152,12 +155,13 @@ impl Reader for Context {
             .call(Request::ReadCoils(addr, cnt))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::ReadCoils(mut coils) => {
+                result.map(|opt_response| match opt_response {
+                    Some(Response::ReadCoils(mut coils)) => {
                         debug_assert!(coils.len() >= cnt.into());
                         coils.truncate(cnt.into());
                         coils
                     }
+                    None => unreachable!("broadcast requests do not return a response"),
                     _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
@@ -172,12 +176,13 @@ impl Reader for Context {
             .call(Request::ReadDiscreteInputs(addr, cnt))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::ReadDiscreteInputs(mut coils) => {
+                result.map(|opt_response| match opt_response {
+                    Some(Response::ReadDiscreteInputs(mut coils)) => {
                         debug_assert!(coils.len() >= cnt.into());
                         coils.truncate(cnt.into());
                         coils
                     }
+                    None => unreachable!("broadcast requests do not return a response"),
                     _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
@@ -192,11 +197,12 @@ impl Reader for Context {
             .call(Request::ReadInputRegisters(addr, cnt))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::ReadInputRegisters(words) => {
+                result.map(|opt_response| match opt_response {
+                    Some(Response::ReadInputRegisters(words)) => {
                         debug_assert_eq!(words.len(), cnt.into());
                         words
                     }
+                    None => unreachable!("broadcast requests do not return a response"),
                     _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
@@ -211,11 +217,12 @@ impl Reader for Context {
             .call(Request::ReadHoldingRegisters(addr, cnt))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::ReadHoldingRegisters(words) => {
+                result.map(|opt_response| match opt_response {
+                    Some(Response::ReadHoldingRegisters(words)) => {
                         debug_assert_eq!(words.len(), cnt.into());
                         words
                     }
+                    None => unreachable!("broadcast requests do not return a response"),
                     _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
@@ -237,11 +244,12 @@ impl Reader for Context {
             ))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::ReadWriteMultipleRegisters(words) => {
+                result.map(|opt_response| match opt_response {
+                    Some(Response::ReadWriteMultipleRegisters(words)) => {
                         debug_assert_eq!(words.len(), read_count.into());
                         words
                     }
+                    None => unreachable!("broadcast requests do not return a response"),
                     _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
@@ -283,8 +291,9 @@ impl Reader for Context {
             .call(Request::ReadDeviceIdentification(read_code, object_id))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::ReadDeviceIdentification(response) => response,
+                result.map(|opt_response| match opt_response {
+                    Some(Response::ReadDeviceIdentification(response)) => response,
+                    None => unreachable!("broadcast requests do not return a response"),
                     _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
@@ -298,12 +307,16 @@ impl Writer for Context {
             .call(Request::WriteSingleCoil(addr, coil))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::WriteSingleCoil(rsp_addr, rsp_coil) => {
-                        debug_assert_eq!(addr, rsp_addr);
-                        debug_assert_eq!(coil, rsp_coil);
+                result.map(|opt_response| {
+                    if let Some(response) = opt_response {
+                        match response {
+                            Response::WriteSingleCoil(rsp_addr, rsp_coil) => {
+                                debug_assert_eq!(addr, rsp_addr);
+                                debug_assert_eq!(coil, rsp_coil);
+                            }
+                            _ => unreachable!("call() should reject mismatching responses"),
+                        }
                     }
-                    _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
     }
@@ -314,12 +327,16 @@ impl Writer for Context {
             .call(Request::WriteMultipleCoils(addr, Cow::Borrowed(coils)))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::WriteMultipleCoils(rsp_addr, rsp_cnt) => {
-                        debug_assert_eq!(addr, rsp_addr);
-                        debug_assert_eq!(cnt, rsp_cnt.into());
+                result.map(|opt_response| {
+                    if let Some(response) = opt_response {
+                        match response {
+                            Response::WriteMultipleCoils(rsp_addr, rsp_cnt) => {
+                                debug_assert_eq!(addr, rsp_addr);
+                                debug_assert_eq!(cnt, rsp_cnt.into());
+                            }
+                            _ => unreachable!("call() should reject mismatching responses"),
+                        }
                     }
-                    _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
     }
@@ -329,12 +346,16 @@ impl Writer for Context {
             .call(Request::WriteSingleRegister(addr, word))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::WriteSingleRegister(rsp_addr, rsp_word) => {
-                        debug_assert_eq!(addr, rsp_addr);
-                        debug_assert_eq!(word, rsp_word);
+                result.map(|opt_response| {
+                    if let Some(response) = opt_response {
+                        match response {
+                            Response::WriteSingleRegister(rsp_addr, rsp_word) => {
+                                debug_assert_eq!(addr, rsp_addr);
+                                debug_assert_eq!(word, rsp_word);
+                            }
+                            _ => unreachable!("call() should reject mismatching responses"),
+                        }
                     }
-                    _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
     }
@@ -349,12 +370,16 @@ impl Writer for Context {
             .call(Request::WriteMultipleRegisters(addr, Cow::Borrowed(data)))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::WriteMultipleRegisters(rsp_addr, rsp_cnt) => {
-                        debug_assert_eq!(addr, rsp_addr);
-                        debug_assert_eq!(cnt, rsp_cnt.into());
+                result.map(|opt_response| {
+                    if let Some(response) = opt_response {
+                        match response {
+                            Response::WriteMultipleRegisters(rsp_addr, rsp_cnt) => {
+                                debug_assert_eq!(addr, rsp_addr);
+                                debug_assert_eq!(cnt, rsp_cnt.into());
+                            }
+                            _ => unreachable!("call() should reject mismatching responses"),
+                        }
                     }
-                    _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
     }
@@ -369,13 +394,17 @@ impl Writer for Context {
             .call(Request::MaskWriteRegister(addr, and_mask, or_mask))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::MaskWriteRegister(rsp_addr, rsp_and_mask, rsp_or_mask) => {
-                        debug_assert_eq!(addr, rsp_addr);
-                        debug_assert_eq!(and_mask, rsp_and_mask);
-                        debug_assert_eq!(or_mask, rsp_or_mask);
+                result.map(|opt_response| {
+                    if let Some(response) = opt_response {
+                        match response {
+                            Response::MaskWriteRegister(rsp_addr, rsp_and_mask, rsp_or_mask) => {
+                                debug_assert_eq!(addr, rsp_addr);
+                                debug_assert_eq!(and_mask, rsp_and_mask);
+                                debug_assert_eq!(or_mask, rsp_or_mask);
+                            }
+                            _ => unreachable!("call() should reject mismatching responses"),
+                        }
                     }
-                    _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
     }
@@ -427,10 +456,10 @@ mod tests {
 
     #[async_trait]
     impl Client for ClientMock {
-        async fn call(&mut self, request: Request<'_>) -> Result<Response> {
+        async fn call(&mut self, request: Request<'_>) -> Result<Option<Response>> {
             *self.last_request.lock().unwrap() = Some(request.into_owned());
             match self.next_response.take().unwrap() {
-                Ok(response) => Ok(response),
+                Ok(response) => Ok(response.map(Some)),
                 Err(Error::Transport(err)) => {
                     Err(io::Error::new(err.kind(), format!("{err}")).into())
                 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -263,8 +263,9 @@ impl Reader for Context {
             .call(Request::ReadFileRecord(Cow::Borrowed(sub_requests)))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::ReadFileRecord(sub_responses) => sub_responses,
+                result.map(|opt_response| match opt_response {
+                    Some(Response::ReadFileRecord(sub_responses)) => sub_responses,
+                    None => unreachable!("broadcast requests do not return a response"),
                     _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
@@ -275,8 +276,9 @@ impl Reader for Context {
             .call(Request::ReadFifoQueue(addr))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::ReadFifoQueue(data) => data,
+                result.map(|opt_response| match opt_response {
+                    Some(Response::ReadFifoQueue(data)) => data,
+                    None => unreachable!("broadcast requests do not return a response"),
                     _ => unreachable!("call() should reject mismatching responses"),
                 })
             })
@@ -417,8 +419,9 @@ impl Writer for Context {
             .call(Request::WriteFileRecord(Cow::Borrowed(sub_requests)))
             .await
             .map(|result| {
-                result.map(|response| match response {
-                    Response::WriteFileRecord(sub_reqs) => sub_reqs,
+                result.map(|opt_response| match opt_response {
+                    Some(Response::WriteFileRecord(sub_reqs)) => sub_reqs,
+                    None => unreachable!("broadcast requests do not return a response"),
                     _ => unreachable!("call() should reject mismatching responses"),
                 })
             })

--- a/src/client/sync/mod.rs
+++ b/src/client/sync/mod.rs
@@ -43,7 +43,7 @@ where
 
 /// A transport independent synchronous client trait.
 pub trait Client: SlaveContext {
-    fn call(&mut self, req: Request<'_>) -> Result<Response>;
+    fn call(&mut self, req: Request<'_>) -> Result<Option<Response>>;
 }
 
 /// A transport independent synchronous reader trait.
@@ -117,7 +117,7 @@ impl Context {
 }
 
 impl Client for Context {
-    fn call(&mut self, req: Request<'_>) -> Result<Response> {
+    fn call(&mut self, req: Request<'_>) -> Result<Option<Response>> {
         block_on_with_timeout(&self.runtime, self.timeout, self.async_ctx.call(req))
     }
 }

--- a/src/server/rtu.rs
+++ b/src/server/rtu.rs
@@ -111,7 +111,7 @@ where
         // For RTU, broadcast requests (SlaveId=0) are processed but
         // must not put a response on the bus.
         if slave.is_broadcast() {
-            log::trace!("Not sending response for broadcast request {hdr:?} (function = {fc})");
+            log::trace!("Not sending response for broadcast request (function = {fc})");
         } else {
             framed
                 .send(ResponseAdu {
@@ -120,7 +120,9 @@ where
                 })
                 .await
                 .inspect_err(|err| {
-                    log::debug!("Failed to send response for request {hdr:?} (function = {fc}): {err}");
+                    log::debug!(
+                        "Failed to send response for request {hdr:?} (function = {fc}): {err}"
+                    );
                 })?;
         }
     }

--- a/src/server/rtu.rs
+++ b/src/server/rtu.rs
@@ -15,6 +15,7 @@ use crate::{
         ExceptionResponse, OptionalResponsePdu, RequestPdu,
         rtu::{RequestAdu, ResponseAdu},
     },
+    slave::Slave,
 };
 
 use super::{Service, Terminated};
@@ -92,6 +93,7 @@ where
         } = &request_adu;
         let hdr = *hdr;
         let fc = request.function_code();
+        let slave = Slave::from(hdr.slave_id);
         let OptionalResponsePdu(Some(response_pdu)) = service
             .call(request_adu.into())
             .await
@@ -106,15 +108,21 @@ where
             continue;
         };
 
-        framed
-            .send(ResponseAdu {
-                hdr,
-                pdu: response_pdu,
-            })
-            .await
-            .inspect_err(|err| {
-                log::debug!("Failed to send response for request {hdr:?} (function = {fc}): {err}");
-            })?;
+        // For RTU, broadcast requests (SlaveId=0) are processed but
+        // must not put a response on the bus.
+        if slave.is_broadcast() {
+            log::trace!("Not sending response for broadcast request {hdr:?} (function = {fc})");
+        } else {
+            framed
+                .send(ResponseAdu {
+                    hdr,
+                    pdu: response_pdu,
+                })
+                .await
+                .inspect_err(|err| {
+                    log::debug!("Failed to send response for request {hdr:?} (function = {fc}): {err}");
+                })?;
+        }
     }
     Ok(())
 }

--- a/src/server/rtu_over_tcp.rs
+++ b/src/server/rtu_over_tcp.rs
@@ -20,6 +20,7 @@ use crate::{
         ExceptionResponse, OptionalResponsePdu, RequestPdu,
         rtu::{RequestAdu, ResponseAdu},
     },
+    slave::Slave,
 };
 
 use super::{Service, Terminated};
@@ -158,6 +159,7 @@ where
         } = &request_adu;
         let hdr = *hdr;
         let fc = request.function_code();
+        let slave = Slave::from(hdr.slave_id);
         let OptionalResponsePdu(Some(response_pdu)) = service
             .call(request_adu.into())
             .await
@@ -172,15 +174,21 @@ where
             continue;
         };
 
-        framed
-            .send(ResponseAdu {
-                hdr,
-                pdu: response_pdu,
-            })
-            .await
-            .inspect_err(|err| {
-                log::debug!("Failed to send response for request {hdr:?} (function = {fc}): {err}");
-            })?;
+        // For RTU, broadcast requests (SlaveId=0) are processed but
+        // must not send back a response.
+        if slave.is_broadcast() {
+            log::trace!("Not sending response for broadcast request {hdr:?} (function = {fc})");
+        } else {
+            framed
+                .send(ResponseAdu {
+                    hdr,
+                    pdu: response_pdu,
+                })
+                .await
+                .inspect_err(|err| {
+                    log::debug!("Failed to send response for request {hdr:?} (function = {fc}): {err}");
+                })?;
+        }
     }
 
     Ok(())

--- a/src/server/rtu_over_tcp.rs
+++ b/src/server/rtu_over_tcp.rs
@@ -177,7 +177,7 @@ where
         // For RTU, broadcast requests (SlaveId=0) are processed but
         // must not send back a response.
         if slave.is_broadcast() {
-            log::trace!("Not sending response for broadcast request {hdr:?} (function = {fc})");
+            log::trace!("Not sending response for broadcast request (function = {fc})");
         } else {
             framed
                 .send(ResponseAdu {
@@ -186,7 +186,9 @@ where
                 })
                 .await
                 .inspect_err(|err| {
-                    log::debug!("Failed to send response for request {hdr:?} (function = {fc}): {err}");
+                    log::debug!(
+                        "Failed to send response for request {hdr:?} (function = {fc}): {err}"
+                    );
                 })?;
         }
     }

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -143,10 +143,7 @@ mod tests {
     };
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, Result};
 
-    use crate::{
-        Error,
-        service::{rtu::Header, verify_response_header},
-    };
+    use crate::service::{rtu::Header, verify_response_header};
 
     #[test]
     fn validate_same_headers() {

--- a/src/service/rtu.rs
+++ b/src/service/rtu.rs
@@ -52,7 +52,7 @@ where
         RequestAdu { hdr, pdu }
     }
 
-    async fn call(&mut self, req: Request<'_>) -> Result<Response> {
+    async fn call(&mut self, req: Request<'_>) -> Result<Option<Response>> {
         log::debug!("Call {req:?}");
 
         let req_function_code = req.function_code();
@@ -63,6 +63,11 @@ where
 
         framed.read_buffer_mut().clear();
         framed.send(req_adu).await?;
+
+        // Broadcast requests (slave ID 0) do not receive a response.
+        if Slave::from(req_hdr.slave_id).is_broadcast() {
+            return Ok(Ok(None));
+        }
 
         let res_adu = framed
             .next()
@@ -92,7 +97,7 @@ where
             .into());
         }
 
-        Ok(result.map_err(
+        Ok(result.map(Some).map_err(
             |ExceptionResponse {
                  function: _,
                  exception,
@@ -120,7 +125,7 @@ impl<T> crate::client::Client for Client<T>
 where
     T: AsyncRead + AsyncWrite + Send + Unpin,
 {
-    async fn call(&mut self, req: Request<'_>) -> Result<Response> {
+    async fn call(&mut self, req: Request<'_>) -> Result<Option<Response>> {
         self.call(req).await
     }
 
@@ -199,17 +204,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_broken_pipe() {
+    async fn handle_broadcast_no_response() {
         let transport = MockTransport;
         let mut client =
             crate::service::rtu::Client::new(transport, crate::service::rtu::Slave::broadcast());
         let res = client
             .call(crate::service::rtu::Request::ReadCoils(0x00, 5))
             .await;
-        assert!(res.is_err());
-        let err = res.err().unwrap();
-        assert!(
-            matches!(err, Error::Transport(err) if err.kind() == std::io::ErrorKind::BrokenPipe)
-        );
+        // Broadcast requests should return Ok(Ok(None)) — no response expected.
+        assert!(matches!(res, Ok(Ok(None))));
     }
 }

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -100,11 +100,6 @@ where
         framed.read_buffer_mut().clear();
         framed.send(req_adu).await?;
 
-        // Broadcast requests (unit ID 0) do not receive a response.
-        if Slave::from(req_hdr.unit_id).is_broadcast() {
-            return Ok(Ok(None));
-        }
-
         let res_adu = framed.next().await.ok_or_else(io::Error::last_os_error)??;
         let ResponseAdu {
             hdr: res_hdr,

--- a/src/service/tcp.rs
+++ b/src/service/tcp.rs
@@ -88,7 +88,7 @@ where
         Ok(framed)
     }
 
-    pub(crate) async fn call(&mut self, req: Request<'_>) -> Result<Response> {
+    pub(crate) async fn call(&mut self, req: Request<'_>) -> Result<Option<Response>> {
         log::debug!("Call {req:?}");
 
         let req_function_code = req.function_code();
@@ -99,6 +99,11 @@ where
 
         framed.read_buffer_mut().clear();
         framed.send(req_adu).await?;
+
+        // Broadcast requests (unit ID 0) do not receive a response.
+        if Slave::from(req_hdr.unit_id).is_broadcast() {
+            return Ok(Ok(None));
+        }
 
         let res_adu = framed.next().await.ok_or_else(io::Error::last_os_error)??;
         let ResponseAdu {
@@ -125,7 +130,7 @@ where
             .into());
         }
 
-        Ok(result.map_err(
+        Ok(result.map(Some).map_err(
             |ExceptionResponse {
                  function: _,
                  exception,
@@ -153,7 +158,7 @@ impl<T> crate::client::Client for Client<T>
 where
     T: AsyncRead + AsyncWrite + Send + Unpin,
 {
-    async fn call(&mut self, req: Request<'_>) -> Result<Response> {
+    async fn call(&mut self, req: Request<'_>) -> Result<Option<Response>> {
         self.call(req).await
     }
 


### PR DESCRIPTION
This implements the broadcast feature for RTU. By the spec, if the Slave ID = 0, then all devices should process and execute the request, but none should put a response on the bus.

So, this PR updates the RTU clients and servers:

- For the client: If the request is a broadcast, the client sends the request, but does not await a response.
- For the server: When the request is received, it is processed, but no response is sent.

I am fairly certain this does not pertain to TCP clients and servers, so the behavior there was not changed. The specs say that zero is valid and normal for a TCP transaction.

I was not sure what to do about RTU over TCP. I implemented the broadcast behavior. But if that is not correct, I can remove it.