### PR TITLE
fix(rtu) Remove any leading 0's from buffer during decode

### DIFF
--- a/src/codec/rtu.rs
+++ b/src/codec/rtu.rs
@@ -300,6 +300,10 @@ where
 {
     const MAX_RETRIES: usize = 20;
 
+    while buf.starts_with(&[b'\0']) {
+        drop(buf.split_to(1));
+    }
+
     for _i in 0..MAX_RETRIES {
         let result = get_pdu_len(buf).and_then(|pdu_len| {
             let Some(pdu_len) = pdu_len else {


### PR DESCRIPTION
This was intended to solve [this issue](https://github.com/slowtec/tokio-modbus/issues/374)

It seems to have fixed the issues I was having, but I don't know if it would be good as a general-purpose solution. I'm definitely not an expert when it comes to this, but I figured my solution might be able to help narrow things down even if it's wrong. 