### PR TITLE
Add transport-level slave ID filtering to RTU server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Unreleased
 
+- Server: Add transport-level slave ID filtering to the RTU server via the
+  `Server::with_slave_id()` builder method. Requests addressed to other slave
+  IDs are silently ignored, as required by the Modbus RTU specification
+  ([#378](https://github.com/slowtec/tokio-modbus/pull/378)).
+
 ## v0.17.0 (2025-10-22)
 
 - Breaking change (behavior): Guess response length for custom function codes

--- a/examples/rtu-server-address.rs
+++ b/examples/rtu-server-address.rs
@@ -1,42 +1,34 @@
 // SPDX-FileCopyrightText: Copyright (c) 2017-2026 slowtec GmbH <post@slowtec.de>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! RTU server example with slave address filtering and optional response
+//! RTU server example with transport-level slave address filtering
+//!
+//! Uses [`Server::with_slave_id`] to filter requests at the transport layer,
+//! so the service only receives requests addressed to this device.
+//! Requests for other slave IDs are silently ignored, as required by
+//! the Modbus RTU specification for devices on a shared RS-485 bus.
 
 use std::{future, thread, time::Duration};
 
 use tokio_modbus::{prelude::*, server::rtu::Server};
 
-struct Service {
-    slave: Slave,
-}
-
-impl Service {
-    fn handle(&self, req: SlaveRequest<'_>) -> Result<Option<Response>, ExceptionCode> {
-        let SlaveRequest { slave, request } = req;
-        if slave != self.slave.into() {
-            // Filtering: Ignore requests with mismatching slave IDs.
-            return Ok(None);
-        }
-        match request {
-            Request::ReadInputRegisters(_addr, cnt) => {
-                let mut registers = vec![0; cnt.into()];
-                registers[2] = 0x77;
-                Ok(Some(Response::ReadInputRegisters(registers)))
-            }
-            _ => Err(ExceptionCode::IllegalFunction),
-        }
-    }
-}
+struct Service;
 
 impl tokio_modbus::server::Service for Service {
     type Request = SlaveRequest<'static>;
-    type Response = Option<Response>;
+    type Response = Response;
     type Exception = ExceptionCode;
     type Future = future::Ready<Result<Self::Response, Self::Exception>>;
 
     fn call(&self, req: Self::Request) -> Self::Future {
-        future::ready(self.handle(req))
+        match req.request {
+            Request::ReadInputRegisters(_addr, cnt) => {
+                let mut registers = vec![0; cnt.into()];
+                registers[2] = 0x77;
+                future::ready(Ok(Response::ReadInputRegisters(registers)))
+            }
+            _ => future::ready(Err(ExceptionCode::IllegalFunction)),
+        }
     }
 }
 
@@ -49,8 +41,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Starting up server...");
     let _server = thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let server = Server::new(server_serial);
-        let service = Service { slave };
+        let server = Server::new(server_serial).with_slave_id(slave);
+        let service = Service;
         rt.block_on(async {
             if let Err(err) = server.serve_forever(service).await {
                 eprintln!("{err}");

--- a/src/server/rtu.rs
+++ b/src/server/rtu.rs
@@ -6,6 +6,7 @@
 use std::{future::Future, io, path::Path};
 
 use futures_util::{FutureExt as _, SinkExt as _, StreamExt as _};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_serial::SerialStream;
 use tokio_util::codec::Framed;
 
@@ -15,6 +16,7 @@ use crate::{
         ExceptionResponse, OptionalResponsePdu, RequestPdu,
         rtu::{RequestAdu, ResponseAdu},
     },
+    slave::SlaveId,
 };
 
 use super::{Service, Terminated};
@@ -22,6 +24,7 @@ use super::{Service, Terminated};
 #[derive(Debug)]
 pub struct Server {
     serial: SerialStream,
+    slave_id: Option<SlaveId>,
 }
 
 impl Server {
@@ -29,13 +32,32 @@ impl Server {
     pub fn new_from_path<P: AsRef<Path>>(p: P, baud_rate: u32) -> io::Result<Self> {
         let serial =
             SerialStream::open(&tokio_serial::new(p.as_ref().to_string_lossy(), baud_rate))?;
-        Ok(Server { serial })
+        Ok(Server {
+            serial,
+            slave_id: None,
+        })
     }
 
     /// set up a new [`Server`] instance based on a pre-configured [`SerialStream`] instance
     #[must_use]
     pub fn new(serial: SerialStream) -> Self {
-        Server { serial }
+        Server {
+            serial,
+            slave_id: None,
+        }
+    }
+
+    /// Configure the server to only respond to requests addressed to the given slave ID.
+    ///
+    /// Requests for other slave IDs are silently ignored at the transport layer,
+    /// as required by the Modbus RTU specification for devices on a shared RS-485 bus.
+    ///
+    /// By default (without calling this method), the server responds to all requests
+    /// regardless of slave ID.
+    #[must_use]
+    pub fn with_slave_id(mut self, slave_id: impl Into<SlaveId>) -> Self {
+        self.slave_id = Some(slave_id.into());
+        self
     }
 
     /// Process Modbus RTU requests.
@@ -45,7 +67,7 @@ impl Server {
         S::Request: From<RequestAdu<'static>> + Send,
     {
         let framed = Framed::new(self.serial, ServerCodec::default());
-        process(framed, service).await
+        process(framed, service, self.slave_id).await
     }
 
     /// Process Modbus RTU requests until finished or aborted.
@@ -61,7 +83,7 @@ impl Server {
         let framed = Framed::new(self.serial, ServerCodec::default());
         let abort_signal = abort_signal.fuse();
         tokio::select! {
-            res = process(framed, service) => {
+            res = process(framed, service, self.slave_id) => {
                 res.map(|()| Terminated::Finished)
             },
             () = abort_signal => {
@@ -72,10 +94,15 @@ impl Server {
 }
 
 /// frame wrapper around the underlying service's responses to forwarded requests
-async fn process<S>(mut framed: Framed<SerialStream, ServerCodec>, service: S) -> io::Result<()>
+async fn process<S, T>(
+    mut framed: Framed<T, ServerCodec>,
+    service: S,
+    slave_id: Option<SlaveId>,
+) -> io::Result<()>
 where
     S: Service + Send + Sync + 'static,
     S::Request: From<RequestAdu<'static>> + Send,
+    T: AsyncRead + AsyncWrite + Unpin,
 {
     loop {
         let Some(request_adu) = framed.next().await.transpose().inspect_err(|err| {
@@ -91,6 +118,18 @@ where
             pdu: RequestPdu(request),
         } = &request_adu;
         let hdr = *hdr;
+
+        if let Some(id) = slave_id {
+            if hdr.slave_id != id {
+                log::trace!(
+                    "Ignoring request for slave {}, expected {}",
+                    hdr.slave_id,
+                    id
+                );
+                continue;
+            }
+        }
+
         let fc = request.function_code();
         let OptionalResponsePdu(Some(response_pdu)) = service
             .call(request_adu.into())
@@ -117,4 +156,105 @@ where
             })?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::{future, time::Duration};
+
+    use tokio::net::{TcpListener, TcpStream};
+
+    use crate::{
+        client,
+        client::Reader as _,
+        prelude::{ExceptionCode, Request, Response, Slave},
+        server::Service,
+    };
+
+    struct TestService;
+
+    impl Service for TestService {
+        type Request = Request<'static>;
+        type Response = Response;
+        type Exception = ExceptionCode;
+        type Future = future::Ready<Result<Self::Response, Self::Exception>>;
+
+        fn call(&self, req: Self::Request) -> Self::Future {
+            match req {
+                Request::ReadInputRegisters(_addr, cnt) => {
+                    let mut registers = vec![0; cnt.into()];
+                    registers[0] = 0x42;
+                    future::ready(Ok(Response::ReadInputRegisters(registers)))
+                }
+                _ => future::ready(Err(ExceptionCode::IllegalFunction)),
+            }
+        }
+    }
+
+    async fn run_server(listener: TcpListener, slave_id: Option<SlaveId>) -> io::Result<()> {
+        let (stream, _addr) = listener.accept().await?;
+        let framed = Framed::new(stream, ServerCodec::default());
+        process(framed, TestService, slave_id).await
+    }
+
+    #[tokio::test]
+    async fn responds_to_matching_slave_id() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let slave = Slave(1);
+
+        tokio::select! {
+            _ = run_server(listener, Some(slave.into())) => unreachable!(),
+            () = async {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                let transport = TcpStream::connect(addr).await.unwrap();
+                let mut ctx = client::rtu::attach_slave(transport, slave);
+                let rsp = ctx.read_input_registers(0x00, 3).await.unwrap();
+                assert_eq!(rsp.unwrap(), vec![0x42, 0x0, 0x0]);
+            } => (),
+        }
+    }
+
+    #[tokio::test]
+    async fn ignores_mismatched_slave_id() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::select! {
+            // Server configured for slave 1
+            _ = run_server(listener, Some(Slave(1).into())) => unreachable!(),
+            () = async {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                // Client sends request to slave 2 — server should NOT respond
+                let transport = TcpStream::connect(addr).await.unwrap();
+                let mut ctx = client::rtu::attach_slave(transport, Slave(2));
+                let result = tokio::time::timeout(
+                    Duration::from_millis(500),
+                    ctx.read_input_registers(0x00, 3),
+                ).await;
+                // Should timeout because the server silently ignores the request
+                assert!(result.is_err(), "Expected timeout, but got a response");
+            } => (),
+        }
+    }
+
+    #[tokio::test]
+    async fn without_slave_id_responds_to_all() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::select! {
+            // Server without slave ID filter — should respond to any slave
+            _ = run_server(listener, None) => unreachable!(),
+            () = async {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                let transport = TcpStream::connect(addr).await.unwrap();
+                let mut ctx = client::rtu::attach_slave(transport, Slave(42));
+                let rsp = ctx.read_input_registers(0x00, 3).await.unwrap();
+                assert_eq!(rsp.unwrap(), vec![0x42, 0x0, 0x0]);
+            } => (),
+        }
+    }
 }


### PR DESCRIPTION
# Summary

  - Adds a with_slave_id() builder method to the RTU Server that filters requests at the transport level before they reach the Service
  - Requests for non-matching slave IDs are silently ignored, as required by the Modbus RTU specification
  - Fully backwards compatible — without with_slave_id(), the server accepts all requests (current behavior unchanged)

  Closes Issue #377

  # Changes

  src/server/rtu.rs:
  - Added slave_id: Option<SlaveId> field to Server
  - Added with_slave_id() builder method
  - Added filtering logic in process(): requests with mismatched slave ID are skipped via continue
  - Made process() generic over T: AsyncRead + AsyncWrite + Unpin (consistent with rtu_over_tcp::process) to enable unit testing without serial hardware

  examples/rtu-server-address.rs:
  - Simplified to use with_slave_id() instead of application-layer filtering in Service::call

  # Tests

  3 new unit tests:
  1. responds_to_matching_slave_id — server responds normally
  2. ignores_mismatched_slave_id — server stays silent (timeout)
  3. without_slave_id_responds_to_all — backwards compatibility confirmed

  All existing CI checks pass (fmt, clippy, doc, 118 tests total).